### PR TITLE
test: instrumented tests for VerseRepository API

### DIFF
--- a/mushaf-core/build.gradle.kts
+++ b/mushaf-core/build.gradle.kts
@@ -102,6 +102,10 @@ dependencies {
     testImplementation(libs.koin.test)
     testImplementation(libs.koin.test.junit4)
     androidTestImplementation(libs.androidx.test.ext.junit)
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.kotlinx.coroutines.test)
+    androidTestImplementation(libs.truth)
+    androidTestImplementation(libs.turbine)
 }
 
 afterEvaluate {

--- a/mushaf-core/src/androidTest/java/com/mushafimad/core/repository/VerseRepositoryTest.kt
+++ b/mushaf-core/src/androidTest/java/com/mushafimad/core/repository/VerseRepositoryTest.kt
@@ -1,0 +1,140 @@
+package com.mushafimad.core.repository
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.mushafimad.core.MushafLibrary
+import com.mushafimad.core.domain.models.MushafType
+import com.mushafimad.core.domain.repository.VerseRepository
+import com.mushafimad.core.util.LibraryTestSetup
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented tests for VerseRepository (Ayah data).
+ *
+ * Covers: QA-6.2 (VerseRepository API) — Issue #22
+ *
+ * TC-6.16  getVersesForPage(1) returns verses for page 1
+ * TC-6.17  getVersesForPage(604) returns verses for the last page
+ * TC-6.18  getVersesForChapter(1) returns 7 verses (Al-Fatiha)
+ * TC-6.19  getVerse(2, 255) returns Ayat Al-Kursi with Arabic text
+ * TC-6.20  getVerse(0, 0) returns null (invalid reference)
+ * TC-6.21  getSajdaVerses() returns known sajda verses
+ * TC-6.22  searchVerses("بسم الله") returns matching verses
+ * TC-6.23  getVersesForPage(page, HAFS_1441) differs from HAFS_1405
+ */
+@RunWith(AndroidJUnit4::class)
+class VerseRepositoryTest {
+
+    private lateinit var repository: VerseRepository
+
+    @Before
+    fun setUp() {
+        LibraryTestSetup.ensureInitialized()
+        repository = MushafLibrary.getVerseRepository()
+    }
+
+    // ──────────────────────────── TC-6.16 ────────────────────────────
+
+    @Test
+    fun getVersesForPage1_returnsNonEmptyList() = runTest {
+        val verses = repository.getVersesForPage(1)
+        assertThat(verses).isNotEmpty()
+    }
+
+    @Test
+    fun getVersesForPage1_versesHaveCorrectChapterNumber() = runTest {
+        val verses = repository.getVersesForPage(1)
+        // Page 1 in HAFS_1441 belongs to Al-Fatiha (chapter 1)
+        assertThat(verses.all { it.chapterNumber == 1 }).isTrue()
+    }
+
+    // ──────────────────────────── TC-6.17 ────────────────────────────
+
+    @Test
+    fun getVersesForPage604_returnsNonEmptyList() = runTest {
+        val verses = repository.getVersesForPage(604)
+        assertThat(verses).isNotEmpty()
+    }
+
+    // ──────────────────────────── TC-6.18 ────────────────────────────
+
+    @Test
+    fun getVersesForChapter1_returnsExactly7Verses() = runTest {
+        val verses = repository.getVersesForChapter(1)
+        assertThat(verses).hasSize(7)
+    }
+
+    @Test
+    fun getVersesForChapter1_versesAreOrderedByNumber() = runTest {
+        val verses = repository.getVersesForChapter(1)
+        val numbers = verses.map { it.number }
+        assertThat(numbers).isInOrder()
+    }
+
+    // ──────────────────────────── TC-6.19 ────────────────────────────
+
+    @Test
+    fun getVerse_returnsAyatAlKursiWithArabicText() = runTest {
+        val verse = repository.getVerse(2, 255)
+
+        assertThat(verse).isNotNull()
+        assertThat(verse!!.chapterNumber).isEqualTo(2)
+        assertThat(verse.number).isEqualTo(255)
+        // Ayat Al-Kursi must contain the known opening word "اللَّهُ"
+        assertThat(verse.text).contains("الله")
+    }
+
+    // ──────────────────────────── TC-6.20 ────────────────────────────
+
+    @Test
+    fun getVerse_returnsNullForInvalidChapter0Verse0() = runTest {
+        assertThat(repository.getVerse(0, 0)).isNull()
+    }
+
+    @Test
+    fun getVerse_returnsNullForNonExistentChapter999() = runTest {
+        assertThat(repository.getVerse(999, 1)).isNull()
+    }
+
+    // ──────────────────────────── TC-6.21 ────────────────────────────
+
+    @Test
+    fun getSajdaVerses_returnsKnownSajdaVerses() = runTest {
+        val sajdaVerses = repository.getSajdaVerses()
+
+        // There are 15 sajda (prostration) verses in the Quran
+        assertThat(sajdaVerses).isNotEmpty()
+        assertThat(sajdaVerses.size).isEqualTo(15)
+    }
+
+    // ──────────────────────────── TC-6.22 ────────────────────────────
+
+    @Test
+    fun searchVerses_arabicBismillahQuery_returnsMatches() = runTest {
+        val results = repository.searchVerses("بسم الله")
+
+        assertThat(results).isNotEmpty()
+        // Every match must contain the query text in its searchable representation
+        assertThat(results.all { verse ->
+            verse.text.contains("الله") || verse.searchableText.contains("الله")
+        }).isTrue()
+    }
+
+    // ──────────────────────────── TC-6.23 ────────────────────────────
+
+    @Test
+    fun getVersesForPage_returnsDifferentSetsForDifferentMushafTypes() = runTest {
+        // Use a page deep enough in the Quran where the two layouts diverge.
+        // Page 100 is in the middle of Al-Baqarah/Al-Imran where layouts differ.
+        val verses1441 = repository.getVersesForPage(100, MushafType.HAFS_1441)
+        val verses1405 = repository.getVersesForPage(100, MushafType.HAFS_1405)
+
+        assertThat(verses1441).isNotEmpty()
+        assertThat(verses1405).isNotEmpty()
+        // The two layouts assign different verse sets to the same page number
+        assertThat(verses1441).isNotEqualTo(verses1405)
+    }
+}

--- a/mushaf-core/src/androidTest/java/com/mushafimad/core/util/LibraryTestSetup.kt
+++ b/mushaf-core/src/androidTest/java/com/mushafimad/core/util/LibraryTestSetup.kt
@@ -1,0 +1,19 @@
+package com.mushafimad.core.util
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.mushafimad.core.MushafLibrary
+
+/**
+ * Shared test setup helper for instrumented tests.
+ *
+ * MushafInitProvider auto-initializes the library via ContentProvider before any test code
+ * runs. Calling initialize() explicitly from tests is safe (the implementation is idempotent),
+ * and also validates TC-1.4 (no crash on double-init).
+ */
+internal object LibraryTestSetup {
+
+    fun ensureInitialized() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        MushafLibrary.initialize(context)
+    }
+}


### PR DESCRIPTION
## Summary

Adds instrumented tests for `VerseRepository` — all 8 test cases from QA-6.2.

## Test coverage

| Test case | Description |
|-----------|-------------|
| TC-6.16 | `getVersesForPage(1)` returns non-empty list with correct chapter assignment |
| TC-6.17 | `getVersesForPage(604)` returns non-empty list |
| TC-6.18 | `getVersesForChapter(1)` returns exactly 7 verses, ordered by number |
| TC-6.19 | `getVerse(2, 255)` returns Ayat Al-Kursi containing "الله" |
| TC-6.20 | `getVerse(0, 0)` and `getVerse(999, 1)` return `null` |
| TC-6.21 | `getSajdaVerses()` returns exactly 15 prostration verses |
| TC-6.22 | `searchVerses("بسم الله")` returns matching results |
| TC-6.23 | Same page number yields different verse sets for `HAFS_1441` vs `HAFS_1405` |

## Running the tests

```bash
./gradlew :mushaf-core:connectedDebugAndroidTest \
  --tests "com.mushafimad.core.repository.VerseRepositoryTest"
```

Closes #22