### PR TITLE
Fix: Eliminate excessive recompositions in audio player UI

### DIFF
--- a/mushaf-ui/src/main/java/com/mushafimad/ui/player/QuranPlayerViewModel.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/player/QuranPlayerViewModel.kt
@@ -75,10 +75,18 @@ internal class QuranPlayerViewModel(
     private fun observePlayerState() {
         viewModelScope.launch {
             audioRepository.getPlayerStateFlow().collect { playerState ->
-                _playbackState.value = playerState.playbackState
-                _currentTimeMs.value = playerState.currentPositionMs
-                _durationMs.value = playerState.durationMs
-                _isRepeatEnabled.value = playerState.isRepeatEnabled
+                // Only update StateFlows when values actually change.
+                // StateFlow skips equal values, so this prevents cascading recompositions
+                // in composables that don't depend on position (e.g. PlayerControls) from
+                // firing on every ~100ms position tick.
+                if (_playbackState.value != playerState.playbackState)
+                    _playbackState.value = playerState.playbackState
+                if (_currentTimeMs.value != playerState.currentPositionMs)
+                    _currentTimeMs.value = playerState.currentPositionMs
+                if (_durationMs.value != playerState.durationMs)
+                    _durationMs.value = playerState.durationMs
+                if (_isRepeatEnabled.value != playerState.isRepeatEnabled)
+                    _isRepeatEnabled.value = playerState.isRepeatEnabled
 
                 // Start/stop verse tracking based on playback state
                 if (playerState.isPlaying) {


### PR DESCRIPTION
## Summary

This pull request Closes #53 where `PlayerControls` was recomposing **400+ times** during playback of only 7 verses — a number that scales directly with chapter length (Al-Baqarah has 286 verses). This PR fixes five distinct root causes across three files, reducing `PlayerControls` recompositions to zero during normal position ticks and to only what is strictly necessary on real state changes.

This contribution is part of the **Itqan Initiative (مبادرة إتقان)**.

---

## Result
| Before | After Fix |
|---|---|
|<img width="1053" height="1015" alt="Image" src="https://github.com/user-attachments/assets/0ba48c6e-c0e2-4b60-805f-b69a86aaf10a" />|<img width="1038" height="1015" alt="Image" src="https://github.com/user-attachments/assets/4adab549-e209-4859-a2dd-ac8ab1e4bb63" />| 
---

## Files Changed

| File | Change |
|---|---|
| `mushaf-ui/.../player/QuranPlayerView.kt` | stabilize lambdas, introduce `PlayerProgressBarContainer` |
| `mushaf-ui/.../mushaf/MushafWithPlayerView.kt` | Stabilize lambdas, move `currentVerseNumber` collection out of top scope |
| `mushaf-ui/.../player/QuranPlayerViewModel.kt` | Guard state assignments to avoid redundant emissions |

---

## Root Causes & Fixes
---

### 1. Inline lambdas recreated on every recompose — `PlayerControls` never skipped

**File:** `QuranPlayerView.kt` and `MushafWithPlayerView.kt`

Compose can skip recomposing a composable only if all its parameters are referentially equal to the previous call. Inline lambdas are new instances on every recompose, so equality always fails.

```kotlin
// Before — new lambda instances on every recompose, PlayerControls never skipped
PlayerControls(
    onPlayPause = { viewModel.togglePlayback() },
    onToggleRepeat = { viewModel.toggleRepeat() },
    onCyclePlaybackRate = { viewModel.cyclePlaybackRate() },
    ...
)

// Also in MushafWithPlayerView:
onPreviousVerse = { playerViewModel.seekToPreviousVerse() },
onNextVerse = { playerViewModel.seekToNextVerse() },
```

```kotlin
// After — stable for the entire ViewModel lifetime
val onPlayPause        = remember(viewModel) { { viewModel.togglePlayback() } }
val onToggleRepeat     = remember(viewModel) { { viewModel.toggleRepeat() } }
val onCyclePlaybackRate = remember(viewModel) { { viewModel.cyclePlaybackRate() } }

val onPreviousVerse = remember(playerViewModel) { { playerViewModel.seekToPreviousVerse() } }
val onNextVerse     = remember(playerViewModel) { { playerViewModel.seekToNextVerse() } }
```

---

### 2. `accentColor` and `onReciterClick` allocated as new instances every recompose

**File:** `QuranPlayerView.kt`

```kotlin
// Before — new Color object and new lambda on every recompose
val accentColor = Color(0xFF2D7F6E)
onReciterClick = { showReciterPicker = true }

// After — stable across recompositions
val accentColor = remember { Color(0xFF2D7F6E) }
val onReciterClick = remember { { showReciterPicker = true } }
```

---

### 3. `currentTimeMs` / `durationMs` collected at top scope — entire tree re-executes every 100ms

**File:** `QuranPlayerView.kt`

Position updates fire ~10 times per second. Collecting them at the `QuranPlayerView` top level causes the entire composable tree — `PlayerHeader`, `PlayerProgressBar`, and `PlayerControls` — to re-execute on every tick, even though only the progress bar needs to change.

**Fix:** Introduce a `PlayerProgressBarContainer` (container/presenter pattern) that owns the high-frequency `collectAsState()` calls in its own recompose scope. The pure `PlayerProgressBar` below it receives plain values and remains previewable and testable. `PlayerControls` and `PlayerHeader` are now completely unaffected by position ticks.

```
Before:
QuranPlayerView          ← re-executes every ~100ms
  ├─ PlayerHeader        ← recomposed every tick ✗
  ├─ PlayerProgressBar   ← recomposed every tick
  └─ PlayerControls      ← recomposed every tick ✗

After:
QuranPlayerView          ← only recomposes on real state changes
  ├─ PlayerHeader        ← skipped during ticks ✓
  ├─ PlayerProgressBarContainer  ← recomposed every tick (correct)
  │    └─ PlayerProgressBar      ← pure composable, no ViewModel dep
  └─ PlayerControls      ← skipped during ticks ✓
```

```kotlin
// New container — isolates high-frequency reads to its own scope
@Composable
private fun PlayerProgressBarContainer(
    viewModel: QuranPlayerViewModel,
    accentColor: Color,
    isLoading: Boolean,
    modifier: Modifier = Modifier
) {
    val currentTimeMs by viewModel.currentTimeMs.collectAsState()
    val durationMs by viewModel.durationMs.collectAsState()

    PlayerProgressBar(
        currentTimeMs = currentTimeMs,
        durationMs = durationMs,
        accentColor = accentColor,
        enabled = durationMs > 0 && !isLoading,
        onSeek = { progress ->
            viewModel.seekTo((durationMs * progress).toLong())
        },
        modifier = modifier
    )
}
```

---

### 5. `currentVerseNumber` collected as state in `MushafWithPlayerView` — recomposes entire parent on every verse change

**File:** `MushafWithPlayerView.kt`

`currentVerseNumber` was collected as `State` at the top of `MushafWithPlayerView`. Since it changes on every verse boundary during playback, it caused the entire parent composable to recompose — recreating all inline lambdas and propagating them down into `PlayerControls`, directly feeding root cause #2.

```kotlin
// Before — recomposes MushafWithPlayerView on every verse change,
// cascading new lambda instances down to PlayerControls
val currentVerseNumber by playerViewModel.currentVerseNumber.collectAsState()

LaunchedEffect(currentVerseNumber, mushafUiState.verses) {
    highlightedVerse = mushafUiState.verses.find { it.number == currentVerseNumber }
}
```

```kotlin
// After — flow collected directly inside LaunchedEffect.
// Only the highlightedVerse state write triggers a targeted recomposition of MushafView,
// MushafWithPlayerView itself is not re-executed.
var highlightedVerse by remember { mutableStateOf<Verse?>(null) }

val verses = mushafUiState.verses
LaunchedEffect(playerViewModel, verses) {
    playerViewModel.currentVerseNumber.collect { verseNumber ->
        highlightedVerse = if (verseNumber != null && verseNumber > 0) {
            verses.find { it.number == verseNumber }
        } else {
            null
        }
    }
}
```

Also fixes the `onPageChanged` lambda which had the same inline recreation problem and a type mismatch (`Unit?` vs `Unit`):

```kotlin
// Before — type mismatch + new lambda every recompose
onPageChanged = { page -> onPageChanged?.invoke(page) }  // returns Unit?

// After — stable, correctly typed
val onPageChangedStable: ((Int) -> Unit)? = remember(onPageChanged) {
    onPageChanged?.let { cb -> { page: Int -> cb(page) } }
}
```

---

### 6. Redundant StateFlow emissions in `QuranPlayerViewModel`

**File:** `QuranPlayerViewModel.kt`

`observePlayerState()` assigned to all four `MutableStateFlow`s on every player state emission, even when values hadn't changed. Added equality guards to avoid emitting unchanged values:

```kotlin
// After — only emits when value actually changes
if (_playbackState.value != playerState.playbackState)
    _playbackState.value = playerState.playbackState
if (_currentTimeMs.value != playerState.currentPositionMs)
    _currentTimeMs.value = playerState.currentPositionMs
if (_durationMs.value != playerState.durationMs)
    _durationMs.value = playerState.durationMs
if (_isRepeatEnabled.value != playerState.isRepeatEnabled)
    _isRepeatEnabled.value = playerState.isRepeatEnabled
```