### PR TITLE
tests: add manual initialization and idempotency automated tests

### DIFF
--- a/sample/src/androidTest/java/com/mushafimad/sampleapp/LibraryInitTest.kt
+++ b/sample/src/androidTest/java/com/mushafimad/sampleapp/LibraryInitTest.kt
@@ -1,0 +1,27 @@
+package com.mushafimad.sampleapp
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.mushafimad.core.MushafLibrary
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LibraryInitTest {
+
+    @Test
+    fun verifyManualInitializationAndIdempotency() {
+         val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+         MushafLibrary.initialize(context)
+        assertTrue("Library should be initialized manually", MushafLibrary.isInitialized())
+
+         try {
+            MushafLibrary.initialize(context)
+            assertTrue("Library should still be initialized after second call", MushafLibrary.isInitialized())
+        } catch (e: Exception) {
+            org.junit.Assert.fail("Library crashed during second initialization: ${e.message}")
+        }
+    }
+}


### PR DESCRIPTION
### Overview
This PR addresses the requirements for manual library initialization and idempotency checks.

### Changes
- **TC-1.3:** Added a test case to verify that `MushafLibrary.initialize(context)` works correctly when called manually.
- **TC-1.4:** Added a test case to ensure that calling the initialization multiple times is idempotent and does not cause any crashes or state issues.

### Testing Status
- Verified that all automated tests pass on a physical device (**realme RMX5303**, Android 15).