### PR TITLE
Add contribution guidelines and GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug Report
+description: Report a bug or issue
+labels: [bug]
+---
+
+## Bug Description
+
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+## Actual Behavior
+
+A clear and concise description of what actually happened.
+
+## Screenshots
+
+If applicable, add screenshots to help explain your problem.
+
+## Environment
+
+- **Android Version**:
+- **Device/Emulator**:
+- **Library Version**:
+- **Gradle Version**:
+- **Kotlin Version**:
+
+## Additional Context
+
+Add any other context about the problem here.
+
+## Logs
+
+If applicable, add logs or stack traces.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature Request
+description: Suggest an idea for this project
+labels: [enhancement]
+---
+
+## Feature Description
+
+A clear and concise description of the feature you'd like to see.
+
+## Problem Statement
+
+Is your feature request related to a problem? Please describe.
+
+## Proposed Solution
+
+Describe the solution you'd like. Include any specific implementation details.
+
+## Alternatives Considered
+
+Describe any alternative solutions or features you've considered.
+
+## Use Cases
+
+Describe the use cases for this feature. Who would benefit and how?
+
+## Additional Context
+
+Add any other context, screenshots, or mockups about the feature request here.
+
+## Implementation Notes
+
+If you have technical implementation ideas, please share them here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+## Description
+
+Please include a summary of the changes and the related issue. Include relevant motivation and context.
+
+Fixes # (issue number)
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Code refactoring
+- [ ] Performance improvement
+
+## Testing
+
+Please describe the tests you ran to verify your changes:
+
+- [ ] Unit tests
+- [ ] Integration tests
+- [ ] UI tests
+- [ ] Manual testing
+
+**Test Configuration**:
+* Android version:
+* Device/Emulator:
+* Library version:
+
+## Checklist
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix/feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published
+
+## Screenshots (if applicable)
+
+Add screenshots to help explain your changes.
+
+## Additional Notes
+
+Add any additional information about the pull request here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,186 @@
+# Contributing to Mushaf Imad Android Library
+
+Thank you for your interest in contributing to the Mushaf Imad Android Library! This document provides guidelines and instructions for contributing to this project.
+
+## Code of Conduct
+
+Please be respectful and considerate of others when contributing to this project. We aim to foster an inclusive and welcoming community.
+
+## How to Contribute
+
+### Reporting Issues
+
+If you find a bug or have a feature request, please check the existing issues first to avoid duplicates. When creating a new issue:
+
+1. Use a clear and descriptive title
+2. Provide detailed steps to reproduce the issue
+3. Include relevant code snippets, logs, or screenshots
+4. Specify your environment (Android version, device, library version)
+
+### Submitting Pull Requests
+
+1. Fork the repository and create your branch from `main`
+2. Make your changes following the code style guidelines
+3. Add or update tests as necessary
+4. Ensure all tests pass
+5. Update documentation if needed
+6. Submit a pull request with a clear description of changes
+
+## Development Setup
+
+### Prerequisites
+
+- Android Studio (latest stable version)
+- JDK 17 or higher
+- Android SDK with API level 24+
+
+### Building the Project
+
+```bash
+./gradlew build
+```
+
+### Running Tests
+
+```bash
+./gradlew test
+```
+
+## Code Style Guidelines
+
+### Kotlin Style
+
+We follow the official [Kotlin Coding Conventions](https://kotlinlang.org/docs/coding-conventions.html). Key points:
+
+- Use 4 spaces for indentation (no tabs)
+- Use `camelCase` for variable and function names
+- Use `PascalCase` for class and interface names
+- Use `UPPER_SNAKE_CASE` for constants
+- Prefer `val` over `var` when possible
+- Use meaningful and descriptive names
+
+### Android Specific Guidelines
+
+- Follow Android [API guidelines](https://developer.android.com/guide/topics/ui/declaring-layout)
+- Use ViewBinding or Compose for UI
+- Handle lifecycle appropriately
+- Use coroutines for asynchronous operations
+- Follow Material Design guidelines
+
+### Architecture
+
+- Follow clean architecture principles
+- Keep components modular and testable
+- Use dependency injection (preferably Hilt)
+- Separate business logic from UI
+
+## Testing Requirements
+
+### Unit Tests
+
+- Write unit tests for all business logic
+- Use JUnit 5 for testing
+- Mock dependencies using MockK
+- Aim for high test coverage (minimum 80%)
+
+### Integration Tests
+
+- Test integration between modules
+- Use Espresso for UI testing
+- Test on multiple API levels
+
+### Running Tests
+
+All tests must pass before submitting a pull request:
+
+```bash
+./gradlew test
+./gradlew connectedAndroidTest
+```
+
+## Pull Request Template
+
+When submitting a pull request, please use the following template:
+
+```markdown
+## Description
+
+Please include a summary of the changes and the related issue. Include relevant motivation and context.
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Code refactoring
+- [ ] Performance improvement
+
+## Testing
+
+Please describe the tests you ran to verify your changes:
+
+- [ ] Unit tests
+- [ ] Integration tests
+- [ ] UI tests
+- [ ] Manual testing
+
+## Checklist
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix/feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published
+
+## Screenshots (if applicable)
+
+Add screenshots to help explain your changes.
+
+## Additional Notes
+
+Add any additional information about the pull request here.
+```
+
+## Commit Guidelines
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/) specification:
+
+- `feat:` New feature
+- `fix:` Bug fix
+- `docs:` Documentation changes
+- `style:` Code style changes (formatting, missing semi-colons, etc.)
+- `refactor:` Code refactoring
+- `test:` Adding or updating tests
+- `chore:` Maintenance tasks
+
+Example:
+```
+feat: add audio playback controls
+fix: resolve memory leak in page rendering
+docs: update installation instructions
+```
+
+## Review Process
+
+1. All pull requests require at least one review
+2. Reviewers will check for code quality, tests, and documentation
+3. Address review comments promptly
+4. Once approved, maintainers will merge the pull request
+
+## Getting Help
+
+If you need help or have questions:
+
+- Check the existing documentation
+- Look at similar issues or pull requests
+- Ask in the issue comments
+
+## License
+
+By contributing to this project, you agree that your contributions will be licensed under the project's license.
+
+Thank you for contributing to Mushaf Imad Android Library!


### PR DESCRIPTION
TL;DR: This adds a CONTRIBUTING.md file and standard GitHub issue/PR templates to define the project's contribution process. Closes #27.

While working on the project setup, I noticed we were missing formal contribution guidelines. This makes it harder for new contributors to get started and can lead to inconsistent PRs. To fix this, I've added a basic structure.

I created a CONTRIBUTING.md that covers the essentials: development environment setup, our code style preferences, and a note that tests should pass before submitting. I also set up GitHub templates for pull requests, bug reports, and feature requests. These templates ask for the right information upfront, which should save time during review.

The contribution doc is meant to be a starting point—it's straightforward and can be expanded later if needed. The templates are the standard ones from GitHub, slightly adjusted to fit the project. They'll help keep issue and PR descriptions consistent.

This should make the first-time contributor experience smoother and give us a clearer baseline for what we expect in submissions. No functional code is changed here; it's all documentation and repository management files.