### PR TITLE
Release 0.2.1 (0.2.0 could not be published)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ A Quran reader library for Android providing high-quality Mushaf page display wi
 [![Android](https://img.shields.io/badge/Platform-Android-green.svg)](https://android.com)
 [![API](https://img.shields.io/badge/API-24%2B-brightgreen.svg)](https://android-arsenal.com/api?level=24)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.0.21-blue.svg)](https://kotlinlang.org)
-[![Version](https://img.shields.io/badge/Version-0.2.0-blue.svg)](https://github.com/YahiaRagae/mushaf-imad-android/releases/tag/0.2.0)
+[![Version](https://img.shields.io/badge/Version-0.2.1-blue.svg)](https://github.com/YahiaRagae/mushaf-imad-android/releases/tag/0.2.1)
 [![JitPack](https://jitpack.io/v/YahiaRagae/mushaf-imad-android.svg)](https://jitpack.io/#YahiaRagae/mushaf-imad-android)
 [![Status](https://img.shields.io/badge/Status-Stable-green.svg)](https://github.com/YahiaRagae/mushaf-imad-android)
 
-> ✅ **Version 0.2.0:** Supports 16 KB memory pages (required by Google Play for apps targeting Android 15+), and fixes a long list of bugs found during QA — including a startup crash and the loss of all saved user data on every launch. The public API is unchanged, so v0.1 code compiles as-is.
+> ✅ **Version 0.2.1:** Supports 16 KB memory pages (required by Google Play for apps targeting Android 15+), and fixes a long list of bugs found during QA — including a startup crash and the loss of all saved user data on every launch. The public API is unchanged, so v0.1 code compiles as-is.
 
 ## Features
 
@@ -59,14 +59,14 @@ Then add the dependency in your app's `build.gradle.kts`:
 **Option A: Full library (UI + Data) — recommended**
 ```kotlin
 dependencies {
-    implementation("com.github.YahiaRagae.mushaf-imad-android:mushaf-ui:0.2.0")
+    implementation("com.github.YahiaRagae.mushaf-imad-android:mushaf-ui:0.2.1")
 }
 ```
 
 **Option B: Data layer only (custom UI)**
 ```kotlin
 dependencies {
-    implementation("com.github.YahiaRagae.mushaf-imad-android:mushaf-core:0.2.0")
+    implementation("com.github.YahiaRagae.mushaf-imad-android:mushaf-core:0.2.1")
 }
 ```
 
@@ -388,12 +388,12 @@ A sample app is included in the `sample/` module demonstrating all library featu
 
 ## Project Status
 
-**Version:** 0.2.0
+**Version:** 0.2.1
 **Status:** Published on [JitPack](https://jitpack.io/#YahiaRagae/mushaf-imad-android)
 
 ---
 
-## What's new in 0.2.0
+## What's new in 0.2.1
 
 The public API is unchanged — v0.1 code compiles as-is.
 
@@ -495,6 +495,6 @@ Developed with care for the Muslim community.
 ---
 
 **Last Updated:** July 2026
-**Current Version:** 0.2.0
+**Current Version:** 0.2.1
 **Status:** Stable - Production Ready
 **Published:** [JitPack](https://jitpack.io/#YahiaRagae/mushaf-imad-android)

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,6 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 # Library versioning
-VERSION_NAME=0.2.0
-VERSION_CODE=3
+VERSION_NAME=0.2.1
+VERSION_CODE=4
 GROUP=com.github.YahiaRagae


### PR DESCRIPTION
Same code as 0.2.0 — only the version string changes.

## Why

JitPack's build of the `0.2.0` tag failed on a **transient Maven Central error** while downloading dependencies:

```
Could not download koin-androidx-compose-3.5.6.aar / coil-compose-2.7.0.aar
  > Got socket exception during request. It might be caused by SSL misconfiguration
```

JitPack then **permanently caches a failed build against the version string**. It serves the cached error and refuses to rebuild — even after the tag was moved to a newer commit (its API still reports the original commit). So `0.2.0` is unusable on JitPack and cannot be recovered.

**No artifact for 0.2.0 was ever produced** (`HTTP 404`), so nothing consumed it and nothing is broken by moving on.

## The build is fine

Building the same commit **by hash** on JitPack — a cache key that isn't poisoned — succeeds:

```
mushaf-ui @ f760dc861d: HTTP 200   status: ok   modules: [mushaf-core, mushaf-ui]
```

And the published artifact was verified to actually contain what consumers need:

| Check | Result |
|---|---|
| `assets/quran.realm` | ✅ 7,667,712 bytes |
| Page images | ✅ 9,665 entries |
| Timing JSON | ✅ 19 entries |
| Consumer ProGuard rules | ✅ `proguard.txt` shipped |
| `mushaf-ui` → `mushaf-core` transitive | ✅ `scope: compile` |

## After merge

Tag `0.2.1` → JitPack builds it fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)