### PR TITLE
0.2.2 — fix two crashes that only hit consumers of the published library

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Quran reader library for Android providing high-quality Mushaf page display wi
 [![Android](https://img.shields.io/badge/Platform-Android-green.svg)](https://android.com)
 [![API](https://img.shields.io/badge/API-24%2B-brightgreen.svg)](https://android-arsenal.com/api?level=24)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.0.21-blue.svg)](https://kotlinlang.org)
-[![Version](https://img.shields.io/badge/Version-0.2.1-blue.svg)](https://github.com/YahiaRagae/mushaf-imad-android/releases/tag/0.2.1)
+[![Version](https://img.shields.io/badge/Version-0.2.2-blue.svg)](https://github.com/YahiaRagae/mushaf-imad-android/releases/tag/0.2.2)
 [![JitPack](https://jitpack.io/v/YahiaRagae/mushaf-imad-android.svg)](https://jitpack.io/#YahiaRagae/mushaf-imad-android)
 [![Status](https://img.shields.io/badge/Status-Stable-green.svg)](https://github.com/YahiaRagae/mushaf-imad-android)
 
@@ -34,7 +34,7 @@ A Quran reader library for Android providing high-quality Mushaf page display wi
 - **Target SDK:** 35 (Android 15)
 - **Kotlin:** 2.0.21
 - **Jetpack Compose:** BOM 2024.12.01
-- **Gradle:** 8.7.3
+- **Android Gradle Plugin:** 8.7.3 (Gradle 8.13)
 
 ---
 
@@ -59,14 +59,14 @@ Then add the dependency in your app's `build.gradle.kts`:
 **Option A: Full library (UI + Data) — recommended**
 ```kotlin
 dependencies {
-    implementation("com.github.YahiaRagae.mushaf-imad-android:mushaf-ui:0.2.1")
+    implementation("com.github.YahiaRagae.mushaf-imad-android:mushaf-ui:0.2.2")
 }
 ```
 
 **Option B: Data layer only (custom UI)**
 ```kotlin
 dependencies {
-    implementation("com.github.YahiaRagae.mushaf-imad-android:mushaf-core:0.2.1")
+    implementation("com.github.YahiaRagae.mushaf-imad-android:mushaf-core:0.2.2")
 }
 ```
 
@@ -104,6 +104,11 @@ class MyApplication : Application() {
 
     <!-- For notifications (Android 13+) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <!--
+        WAKE_LOCK is declared by the library itself and merged in automatically -
+        you do not need to add it.
+    -->
 
     <application
         android:name=".MyApplication"
@@ -249,24 +254,29 @@ enum class MushafType {
 
 ### Available Reciters (18 total)
 
-- Abdul Basit Abdul Samad (عبد الباسط عبد الصمد)
-- Mohamed Siddiq Al-Minshawi (محمد صديق المنشاوي)
-- Mahmoud Khalil Al-Hussary (محمود خليل الحصري)
-- Mahmoud Khalil Al-Hussary - Mujawwad (محمود خليل الحصري - مجود)
-- Mishari Rashid Al-Afasy (مشاري راشد العفاسي)
-- Saad Al-Ghamdi (سعد الغامدي)
-- Maher Al-Muaiqly (ماهر المعيقلي)
-- Abdul Rahman Al-Sudais (عبد الرحمن السديس)
-- Saud Al-Shuraim (سعود الشريم)
-- Ahmed ibn Ali Al-Ajmi (أحمد بن علي العجمي)
-- Yasser Al-Dosari (ياسر الدوسري)
-- Abdullah Basfar (عبد الله بصفر)
-- Khalifa Al-Tunaiji (خليفة الطنيجي)
-- Nasser Al-Qatami (ناصر القطامي)
-- Abdullah Al-Juhani (عبد الله الجهني)
-- Bandar Baleela (بندر بليلة)
-- Muhammad Ayyub (محمد أيوب)
-- Abdullah Al-Matroud (عبد الله المطرود)
+Read from the bundled verse-timing data, so this is exactly what
+`AudioRepository.getAllReciters()` returns and what the reciter picker shows.
+
+| ID | Reciter | Rewaya |
+|----|---------|--------|
+| 1 | Ibrahim Al-Akdar (إبراهيم الأخضر) | حفص عن عاصم |
+| 5 | Ahmad Al-Ajmy (أحمد بن علي العجمي) | حفص عن عاصم |
+| 9 | Ahmad Nauina (أحمد نعينع) | حفص عن عاصم |
+| 10 | Akram Alalaqmi (أكرم العلاقمي) | حفص عن عاصم |
+| 31 | Saud Al-Shuraim (سعود الشريم) | حفص عن عاصم |
+| 32 | Sahl Yassin (سهل ياسين) | حفص عن عاصم |
+| 51 | Abdulbasit Abdulsamad (عبدالباسط عبدالصمد) | المصحف المجود |
+| 53 | Abdulbasit Abdulsamad (عبدالباسط عبدالصمد) | حفص عن عاصم |
+| 60 | Abdullah Basfer (عبدالله بصفر) | حفص عن عاصم |
+| 62 | Abdullah Al-Johany (عبدالله عواد الجهني) | حفص عن عاصم |
+| 67 | Abdulmohsen Al-Qasim (عبدالمحسن القاسم) | حفص عن عاصم |
+| 74 | Ali Alhuthaifi (علي بن عبدالرحمن الحذيفي) | حفص عن عاصم |
+| 78 | Emad Hafez (عماد زهير حافظ) | حفص عن عاصم |
+| 106 | Mohammad Al-Tablaway (محمد الطبلاوي) | حفص عن عاصم |
+| 112 | Mohammed Siddiq Al-Minshawi (محمد صديق المنشاوي) | حفص عن عاصم |
+| 118 | Mahmoud Khalil Al-Hussary (محمود خليل الحصري) | حفص عن عاصم |
+| 159 | Khalid Almohana (خالد المهنا) | حفص عن عاصم |
+| 256 | Ahmad Shaheen (أحمد خليل شاهين) | حفص عن عاصم |
 
 ### Audio Controls
 
@@ -388,10 +398,30 @@ A sample app is included in the `sample/` module demonstrating all library featu
 
 ## Project Status
 
-**Version:** 0.2.1
+**Version:** 0.2.2
 **Status:** Published on [JitPack](https://jitpack.io/#YahiaRagae/mushaf-imad-android)
 
 ---
+
+## What's new in 0.2.2
+
+Two crashes that only ever hit **consumers of the published library** — never the bundled
+sample app, which is why they survived every internal check. Both were found by building a
+real third-party app against `0.2.1` from JitPack.
+
+- **The app died the instant audio started.** `AudioPlaybackService` sets `WAKE_MODE_NETWORK`
+  on the player, which needs `WAKE_LOCK` — but the library never declared it, so the host
+  crashed with `SecurityException: ... android.permission.WAKE_LOCK`. It went unnoticed
+  because the bundled sample declared the permission itself. The library now declares it and
+  it is merged into the host automatically; **you do not need to add it**.
+- **Reading history always threw.** `recordReadingSession()` silently dropped its `verseNumber`
+  and `mushafType` before writing, so every row was stored with an empty mushaf type, and
+  reading one back did `MushafType.valueOf("")` and threw. This was latent until 0.2.1 — which
+  started recording sessions automatically — at which point any app displaying reading history
+  crashed on its first visit. Rows written by 0.2.1 no longer crash on upgrade.
+
+Also: corrected the reciter list in this README (it named people the library does not actually
+ship), and the Gradle/AGP versions.
 
 ## What's new in 0.2.1
 
@@ -495,6 +525,6 @@ Developed with care for the Muslim community.
 ---
 
 **Last Updated:** July 2026
-**Current Version:** 0.2.1
+**Current Version:** 0.2.2
 **Status:** Stable - Production Ready
 **Published:** [JitPack](https://jitpack.io/#YahiaRagae/mushaf-imad-android)

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,6 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 # Library versioning
-VERSION_NAME=0.2.1
-VERSION_CODE=4
+VERSION_NAME=0.2.2
+VERSION_CODE=5
 GROUP=com.github.YahiaRagae

--- a/mushaf-core/src/androidTest/java/com/mushafimad/core/ReadingHistoryRoundTripTest.kt
+++ b/mushaf-core/src/androidTest/java/com/mushafimad/core/ReadingHistoryRoundTripTest.kt
@@ -1,0 +1,75 @@
+package com.mushafimad.core
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.mushafimad.core.domain.models.MushafType
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * A recorded reading session must be readable again.
+ *
+ * In 0.2.1 it was not: recordReadingSession() dropped its verseNumber and
+ * mushafType arguments before they reached the database, so every row was
+ * written with an empty mushaf type, and reading one back did
+ * MushafType.valueOf("") and threw. Nothing caught it because until 0.2.1
+ * nothing ever recorded a session, so the table was always empty and the mapper
+ * never ran. 0.2.1 then started recording sessions automatically - which meant
+ * any consumer that displayed reading history crashed on its first visit.
+ */
+@RunWith(AndroidJUnit4::class)
+class ReadingHistoryRoundTripTest {
+
+    private val repo = MushafLibrary.getReadingHistoryRepository()
+
+    @Test
+    fun recordedSessionCanBeReadBack() = runBlocking {
+        repo.recordReadingSession(
+            chapterNumber = 18,
+            verseNumber = 10,
+            pageNumber = 294,
+            durationSeconds = 42,
+            mushafType = MushafType.HAFS_1441
+        )
+
+        // This threw IllegalArgumentException in 0.2.1
+        val history = repo.getRecentHistory(limit = 10)
+
+        assertThat(history).isNotEmpty()
+        val entry = history.first { it.pageNumber == 294 }
+        assertThat(entry.chapterNumber).isEqualTo(18)
+        assertThat(entry.verseNumber).isEqualTo(10)      // was silently dropped
+        assertThat(entry.durationSeconds).isEqualTo(42)
+        assertThat(entry.mushafType).isEqualTo(MushafType.HAFS_1441)   // was ""
+    }
+
+    @Test
+    fun otherHistoryQueriesShareTheMapperAndAlsoWork() = runBlocking {
+        repo.recordReadingSession(
+            chapterNumber = 2,
+            verseNumber = 255,
+            pageNumber = 42,
+            durationSeconds = 30,
+            mushafType = MushafType.HAFS_1441
+        )
+
+        val now = System.currentTimeMillis()
+        assertThat(repo.getHistoryForDateRange(now - 60_000, now + 60_000)).isNotEmpty()
+        assertThat(repo.getHistoryForChapter(2)).isNotEmpty()
+    }
+
+    @Test
+    fun statsStillWork() = runBlocking {
+        repo.recordReadingSession(
+            chapterNumber = 1,
+            verseNumber = 1,
+            pageNumber = 1,
+            durationSeconds = 15,
+            mushafType = MushafType.HAFS_1441
+        )
+
+        assertThat(repo.getTotalReadingTime()).isGreaterThan(0L)
+        assertThat(repo.getReadChapters()).contains(1)
+    }
+}

--- a/mushaf-core/src/main/AndroidManifest.xml
+++ b/mushaf-core/src/main/AndroidManifest.xml
@@ -10,6 +10,15 @@
     <!-- Post notifications permission (Android 13+) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <!--
+        Required by AudioPlaybackService, which sets WAKE_MODE_NETWORK on the
+        player so a streamed recitation survives the screen turning off. This is
+        the library's own need, so the library declares it: without it the host
+        app dies with a SecurityException the moment audio starts. It went
+        unnoticed because the bundled sample declared the permission itself.
+    -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
     <application>
         <service
             android:name=".data.audio.AudioPlaybackService"

--- a/mushaf-core/src/main/java/com/mushafimad/core/data/local/dao/ReadingHistoryDao.kt
+++ b/mushaf-core/src/main/java/com/mushafimad/core/data/local/dao/ReadingHistoryDao.kt
@@ -26,9 +26,11 @@ internal interface ReadingHistoryDao {
     // Reading History operations
     suspend fun insertHistory(
         chapterNumber: Int,
+        verseNumber: Int,
         pageNumber: Int,
         timestamp: Long,
-        durationSeconds: Int
+        durationSeconds: Int,
+        mushafType: String
     )
 
     suspend fun getRecentHistory(limit: Int): List<ReadingHistoryEntity>

--- a/mushaf-core/src/main/java/com/mushafimad/core/data/local/dao/RealmReadingHistoryDao.kt
+++ b/mushaf-core/src/main/java/com/mushafimad/core/data/local/dao/RealmReadingHistoryDao.kt
@@ -76,16 +76,20 @@ internal class RealmReadingHistoryDao(
 
     override suspend fun insertHistory(
         chapterNumber: Int,
+        verseNumber: Int,
         pageNumber: Int,
         timestamp: Long,
-        durationSeconds: Int
+        durationSeconds: Int,
+        mushafType: String
     ): Unit = withContext(Dispatchers.IO) {
         realm.write {
             val entity = ReadingHistoryEntity().apply {
                 this.chapterNumber = chapterNumber
+                this.verseNumber = verseNumber
                 this.pageNumber = pageNumber
                 this.timestamp = timestamp
                 this.durationSeconds = durationSeconds
+                this.mushafType = mushafType
             }
             copyToRealm(entity)
         }

--- a/mushaf-core/src/main/java/com/mushafimad/core/data/repository/DefaultReadingHistoryRepository.kt
+++ b/mushaf-core/src/main/java/com/mushafimad/core/data/repository/DefaultReadingHistoryRepository.kt
@@ -56,9 +56,11 @@ internal class DefaultReadingHistoryRepository (
     ): Unit = withContext(Dispatchers.IO) {
         readingHistoryDao.insertHistory(
             chapterNumber = chapterNumber,
+            verseNumber = verseNumber,
             pageNumber = pageNumber,
             timestamp = System.currentTimeMillis(),
-            durationSeconds = durationSeconds
+            durationSeconds = durationSeconds,
+            mushafType = mushafType.name
         )
     }
 
@@ -170,8 +172,21 @@ internal class DefaultReadingHistoryRepository (
         return maxOf(longest, current)
     }
 
+    /**
+     * Parse a persisted mushaf type without throwing.
+     *
+     * 0.2.1 wrote reading-history rows without a mushaf type at all, so any
+     * database written by it holds rows with an empty string here. Reading one
+     * back with MushafType.valueOf("") threw, and since 0.2.1 also started
+     * recording sessions automatically, that took down every consumer that
+     * showed reading history. Rows that predate the fix now fall back to the
+     * default rather than crashing the app.
+     */
+    private fun parseMushafType(stored: String): MushafType =
+        MushafType.entries.firstOrNull { it.name == stored } ?: MushafType.HAFS_1441
+
     private fun LastReadPositionEntity.toDomain() = LastReadPosition(
-        mushafType = MushafType.valueOf(mushafType),
+        mushafType = parseMushafType(mushafType),
         chapterNumber = chapterNumber,
         verseNumber = verseNumber,
         pageNumber = pageNumber,
@@ -186,6 +201,6 @@ internal class DefaultReadingHistoryRepository (
         pageNumber = pageNumber,
         timestamp = timestamp,
         durationSeconds = durationSeconds,
-        mushafType = MushafType.valueOf(mushafType)
+        mushafType = parseMushafType(mushafType)
     )
 }


### PR DESCRIPTION
Both bugs were found by building a **real third-party app** against the published `0.2.1` from JitPack (`/Users/yahia/repos/mushaf-consumer-app`). **Neither could ever reproduce in-house**, because the bundled sample app masked both of them.

`0.2.1` is live and broken for any consumer that plays audio or shows reading history.

---

## 🔴 1. The app dies the instant audio starts

`AudioPlaybackService` sets `WAKE_MODE_NETWORK` on the player so a streamed recitation survives the screen turning off. That requires `WAKE_LOCK` — and **the library never declared it**:

```
FATAL EXCEPTION: SecurityException:
  Neither user 10246 nor current process has android.permission.WAKE_LOCK
```

Why we never saw it: **our own sample app declares `WAKE_LOCK` in its manifest**, covering for a permission the *library* needs. Every third-party consumer hits it immediately.

The library now declares it, so it merges into the host automatically — verified present in the packaged AAR manifest. Consumers need to add nothing.

## 🔴 2. Reading history always throws — a regression from 0.2.1

`recordReadingSession()` **dropped its `verseNumber` and `mushafType` arguments** before they reached the database — the DAO's `insertHistory()` did not even take them. So every row was written with an empty mushaf type, and reading one back did `MushafType.valueOf("")` → `IllegalArgumentException`.

This was **latent for as long as it existed**: nothing ever recorded a session, so the table stayed empty and the broken mapper never ran. Then **0.2.1 (#75) started recording sessions automatically** — which populated the table, and turned a dormant bug into a **guaranteed crash on first visit** to any reading-history screen. `getHistoryForDateRange()` and `getHistoryForChapter()` share the mapper and were equally broken.

Fixed:
- the DAO now persists `verseNumber` and `mushafType`;
- the mappers **parse the stored type defensively**, so rows already written by 0.2.1 don't crash on upgrade.

Covered by `ReadingHistoryRoundTripTest` — record a session, read it back. That test is the thing that was missing: #75 added a *writer* without ever testing the *read-back*.

---

## README

- **The reciter list named 18 people the library doesn't ship** (no Al-Afasy, no Al-Sudais, no Al-Ghamdi, no Maher Al-Muaiqly). The real list comes from the bundled timing data and is now taken from it — it's what `getAllReciters()` actually returns.
- `Gradle: 8.7.3` was the **AGP** version (real Gradle is 8.13).
- Noted that `WAKE_LOCK` is inherited from the library.

## Verification

- **17 core instrumented + 6 UI instrumented + 5 unit** tests green
- `apiCheck` clean — every change is `internal`, **public API unchanged**
- Sample builds debug + minified release
- Consumer app confirms the rest of `0.2.1` is sound: reader, search, audio (real playback, verse highlighting), reciter picker, position restore across process death, **a minified R8 release build** (proving the AAR's consumer ProGuard rules ship correctly), and 16 KB clean on a real 16 KB device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)