### PR TITLE
Fix the reciter fallback naming every reciter wrong

### DIFF
--- a/mushaf-core/src/androidTest/java/com/mushafimad/core/ReciterFallbackMatchesShippedDataTest.kt
+++ b/mushaf-core/src/androidTest/java/com/mushafimad/core/ReciterFallbackMatchesShippedDataTest.kt
@@ -1,0 +1,89 @@
+package com.mushafimad.core
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.truth.Truth.assertThat
+import com.mushafimad.core.data.audio.ReciterDataProvider
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * ReciterDataProvider hardcodes a copy of data that already ships in the AAR, and the
+ * copy had drifted from the original completely: every one of its 18 entries named a
+ * different reciter than the timing file with the same id, and pointed at that other
+ * reciter's audio folder. Reciter 1 is Ibrahim Al-Akdar; the table called him Abdul
+ * Basit and served Abdul Basit's recording, while read_1.json timed Al-Akdar's - so a
+ * consumer that hit the fallback would highlight verses against a voice nobody was
+ * hearing.
+ *
+ * Correcting the table once is not a fix, because nothing stopped it drifting in the
+ * first place. This test reads the timing assets the way the library reads them and
+ * fails if the two ever disagree again.
+ */
+@RunWith(AndroidJUnit4::class)
+class ReciterFallbackMatchesShippedDataTest {
+
+    private data class ShippedReciter(
+        val id: Int,
+        val nameArabic: String,
+        val nameEnglish: String,
+        val rewaya: String,
+        val folderUrl: String
+    )
+
+    private fun readShippedReciters(): List<ShippedReciter> {
+        val assets = InstrumentationRegistry.getInstrumentation().targetContext.assets
+        val timingFiles = assets.list("ayah_timing").orEmpty()
+            .filter { it.startsWith("read_") && it.endsWith(".json") }
+
+        return timingFiles.map { fileName ->
+            val json = assets.open("ayah_timing/$fileName").use { input ->
+                JSONObject(input.reader().readText())
+            }
+            ShippedReciter(
+                id = json.getInt("id"),
+                nameArabic = json.getString("name"),
+                nameEnglish = json.getString("name_en"),
+                rewaya = json.getString("rewaya"),
+                folderUrl = json.getString("folder_url")
+            )
+        }.sortedBy { it.id }
+    }
+
+    @Test
+    fun fallbackNamesTheSameRecitersTheTimingFilesDo() {
+        val shipped = readShippedReciters()
+        val fallback = ReciterDataProvider.allReciters.sortedBy { it.id }
+
+        // Guards the guard: if the assets ever vanish from the AAR this test must fail
+        // loudly rather than pass by comparing two empty lists.
+        assertThat(shipped).isNotEmpty()
+
+        assertThat(fallback.map { it.id }).isEqualTo(shipped.map { it.id })
+
+        shipped.zip(fallback).forEach { (expected, actual) ->
+            assertThat(actual.nameEnglish).isEqualTo(expected.nameEnglish)
+            assertThat(actual.nameArabic).isEqualTo(expected.nameArabic)
+            assertThat(actual.rewaya).isEqualTo(expected.rewaya)
+            // The audio folder is the one that silently corrupts playback: get it wrong
+            // and the app plays a different reciter than the timings were measured for.
+            assertThat(actual.folderUrl).isEqualTo(expected.folderUrl)
+        }
+    }
+
+    /**
+     * The default reciter is the one a consumer gets from
+     * AudioRepository.getDefaultReciter() when nothing is selected yet, and
+     * ReciterService.DEFAULT_RECITER_ID hardcodes 1 to mean it. If the fallback's first
+     * entry is not that reciter, those two disagree about who the default is.
+     */
+    @Test
+    fun defaultReciterIsTheLowestShippedId() {
+        val shipped = readShippedReciters()
+        val default = ReciterDataProvider.getDefaultReciter()
+
+        assertThat(default.id).isEqualTo(shipped.first().id)
+        assertThat(default.nameEnglish).isEqualTo(shipped.first().nameEnglish)
+    }
+}

--- a/mushaf-core/src/main/java/com/mushafimad/core/data/audio/ReciterDataProvider.kt
+++ b/mushaf-core/src/main/java/com/mushafimad/core/data/audio/ReciterDataProvider.kt
@@ -3,141 +3,157 @@ package com.mushafimad.core.data.audio
 import com.mushafimad.core.domain.models.ReciterInfo
 
 /**
- * Provider for all available Quran reciters
- * Data matches iOS implementation for compatibility
- * Internal implementation - not exposed in public API
+ * Fallback reciter list, used only when not a single timing file can be read.
+ *
+ * The real source of truth is `assets/ayah_timing/read_<id>.json`: each file carries
+ * both the per-ayah timings and the identity of the recitation they were measured
+ * against (name, rewaya, audio folder). ReciterService builds the live list from
+ * those files and only reaches for this table if every one of them fails to load.
+ *
+ * This table therefore duplicates data that already ships in the AAR, and it had
+ * drifted from it completely - all 18 entries named a different reciter than the
+ * timing file with the same id, and pointed at that other reciter's audio. Reciter 1
+ * is Ibrahim Al-Akdar, not Abdul Basit; asking for id 1 handed you Abdul Basit's
+ * audio while read_1.json timed Al-Akdar's, so the highlighted verse would track a
+ * voice nobody was listening to.
+ *
+ * The entries below are generated from the shipped timing files, and
+ * ReciterFallbackMatchesShippedDataTest fails the build if the two ever disagree
+ * again. Do not hand-edit this list: change the assets, then regenerate.
+ *
+ * Internal implementation - not exposed in public API.
  */
 internal object ReciterDataProvider {
 
     /**
-     * List of all available reciters with timing data
+     * All reciters the library ships timing data for, in id order.
      */
     val allReciters: List<ReciterInfo> = listOf(
         ReciterInfo(
             id = 1,
-            nameArabic = "عبد الباسط عبد الصمد",
-            nameEnglish = "Abdul Basit Abdul Samad",
+            nameArabic = "إبراهيم الأخضر",
+            nameEnglish = "Ibrahim Al-Akdar",
             rewaya = "حفص عن عاصم",
-            folderUrl = "https://server6.mp3quran.net/abas_64/"
+            folderUrl = "https://server6.mp3quran.net/akdr/"
         ),
         ReciterInfo(
             id = 5,
-            nameArabic = "محمد صديق المنشاوي",
-            nameEnglish = "Mohamed Siddiq Al-Minshawi",
+            nameArabic = "أحمد بن علي العجمي",
+            nameEnglish = "Ahmad Al-Ajmy",
             rewaya = "حفص عن عاصم",
-            folderUrl = "https://server10.mp3quran.net/minsh/Rewayat-Hafs-A-n-Assem/"
+            folderUrl = "https://server10.mp3quran.net/ajm/"
         ),
         ReciterInfo(
             id = 9,
-            nameArabic = "محمود خليل الحصري",
-            nameEnglish = "Mahmoud Khalil Al-Hussary",
+            nameArabic = "أحمد نعينع",
+            nameEnglish = "Ahmad Nauina",
             rewaya = "حفص عن عاصم",
-            folderUrl = "https://server13.mp3quran.net/husr/"
+            folderUrl = "https://server11.mp3quran.net/ahmad_nu/"
         ),
         ReciterInfo(
             id = 10,
-            nameArabic = "محمود خليل الحصري (مجود)",
-            nameEnglish = "Mahmoud Khalil Al-Hussary (Mujawwad)",
+            nameArabic = "أكرم العلاقمي",
+            nameEnglish = "Akram Alalaqmi",
             rewaya = "حفص عن عاصم",
-            folderUrl = "https://server13.mp3quran.net/husr/Mujawwad/"
+            folderUrl = "https://server9.mp3quran.net/akrm/"
         ),
         ReciterInfo(
             id = 31,
-            nameArabic = "مشاري راشد العفاسي",
-            nameEnglish = "Mishari Rashid Al-Afasy",
-            rewaya = "حفص عن عاصم",
-            folderUrl = "https://server8.mp3quran.net/afs/"
-        ),
-        ReciterInfo(
-            id = 32,
-            nameArabic = "سعد الغامدي",
-            nameEnglish = "Saad Al-Ghamdi",
-            rewaya = "حفص عن عاصم",
-            folderUrl = "https://server7.mp3quran.net/s_gmd/"
-        ),
-        ReciterInfo(
-            id = 51,
-            nameArabic = "ماهر المعيقلي",
-            nameEnglish = "Maher Al-Muaiqly",
-            rewaya = "حفص عن عاصم",
-            folderUrl = "https://server12.mp3quran.net/maher/"
-        ),
-        ReciterInfo(
-            id = 53,
-            nameArabic = "عبد الرحمن السديس",
-            nameEnglish = "Abdul Rahman Al-Sudais",
-            rewaya = "حفص عن عاصم",
-            folderUrl = "https://server11.mp3quran.net/sds/"
-        ),
-        ReciterInfo(
-            id = 60,
             nameArabic = "سعود الشريم",
             nameEnglish = "Saud Al-Shuraim",
             rewaya = "حفص عن عاصم",
             folderUrl = "https://server7.mp3quran.net/shur/"
         ),
         ReciterInfo(
-            id = 62,
-            nameArabic = "أحمد بن علي العجمي",
-            nameEnglish = "Ahmed ibn Ali Al-Ajmi",
+            id = 32,
+            nameArabic = "سهل ياسين",
+            nameEnglish = "Sahl Yassin",
             rewaya = "حفص عن عاصم",
-            folderUrl = "https://server10.mp3quran.net/ajm/"
+            folderUrl = "https://server6.mp3quran.net/shl/"
+        ),
+        ReciterInfo(
+            id = 51,
+            nameArabic = "عبدالباسط عبدالصمد",
+            nameEnglish = "Abdulbasit Abdulsamad",
+            rewaya = "المصحف المجود",
+            folderUrl = "https://server7.mp3quran.net/basit/Almusshaf-Al-Mojawwad/"
+        ),
+        ReciterInfo(
+            id = 53,
+            nameArabic = "عبدالباسط عبدالصمد",
+            nameEnglish = "Abdulbasit Abdulsamad",
+            rewaya = "حفص عن عاصم",
+            folderUrl = "https://server7.mp3quran.net/basit/"
+        ),
+        ReciterInfo(
+            id = 60,
+            nameArabic = "عبدالله بصفر",
+            nameEnglish = "Abdullah Basfer",
+            rewaya = "حفص عن عاصم",
+            folderUrl = "https://server6.mp3quran.net/bsfr/"
+        ),
+        ReciterInfo(
+            id = 62,
+            nameArabic = "عبدالله عواد الجهني",
+            nameEnglish = "Abdullah Al-Johany",
+            rewaya = "حفص عن عاصم",
+            folderUrl = "https://server13.mp3quran.net/jhn/"
         ),
         ReciterInfo(
             id = 67,
-            nameArabic = "ياسر الدوسري",
-            nameEnglish = "Yasser Al-Dosari",
+            nameArabic = "عبدالمحسن القاسم",
+            nameEnglish = "Abdulmohsen Al-Qasim",
             rewaya = "حفص عن عاصم",
-            folderUrl = "https://server11.mp3quran.net/yasser/"
+            folderUrl = "https://server8.mp3quran.net/qasm/"
         ),
         ReciterInfo(
             id = 74,
-            nameArabic = "عبد الله بصفر",
-            nameEnglish = "Abdullah Basfar",
+            nameArabic = "علي بن عبدالرحمن الحذيفي",
+            nameEnglish = "Ali Alhuthaifi",
             rewaya = "حفص عن عاصم",
-            folderUrl = "https://server11.mp3quran.net/bsfr/"
+            folderUrl = "https://server9.mp3quran.net/hthfi/"
         ),
         ReciterInfo(
             id = 78,
-            nameArabic = "خليفة الطنيجي",
-            nameEnglish = "Khalifa Al-Tunaiji",
+            nameArabic = "عماد زهير حافظ",
+            nameEnglish = "Emad Hafez",
             rewaya = "حفص عن عاصم",
-            folderUrl = "https://server11.mp3quran.net/taniji/"
+            folderUrl = "https://server6.mp3quran.net/hafz/"
         ),
         ReciterInfo(
             id = 106,
-            nameArabic = "ناصر القطامي",
-            nameEnglish = "Nasser Al-Qatami",
+            nameArabic = "محمد الطبلاوي",
+            nameEnglish = "Mohammad Al-Tablaway",
             rewaya = "حفص عن عاصم",
-            folderUrl = "https://server6.mp3quran.net/qtm/"
+            folderUrl = "https://server12.mp3quran.net/tblawi/"
         ),
         ReciterInfo(
             id = 112,
-            nameArabic = "عبد الله الجهني",
-            nameEnglish = "Abdullah Al-Juhani",
+            nameArabic = "محمد صديق المنشاوي",
+            nameEnglish = "Mohammed Siddiq Al-Minshawi",
             rewaya = "حفص عن عاصم",
-            folderUrl = "https://server11.mp3quran.net/jhn/"
+            folderUrl = "https://server10.mp3quran.net/minsh/"
         ),
         ReciterInfo(
             id = 118,
-            nameArabic = "بندر بليلة",
-            nameEnglish = "Bandar Baleela",
+            nameArabic = "محمود خليل الحصري",
+            nameEnglish = "Mahmoud Khalil Al-Hussary",
             rewaya = "حفص عن عاصم",
-            folderUrl = "https://server10.mp3quran.net/bnd/"
+            folderUrl = "https://server13.mp3quran.net/husr/"
         ),
         ReciterInfo(
             id = 159,
-            nameArabic = "محمد أيوب",
-            nameEnglish = "Muhammad Ayyub",
+            nameArabic = "خالد المهنا",
+            nameEnglish = "Khalid Almohana",
             rewaya = "حفص عن عاصم",
-            folderUrl = "https://server8.mp3quran.net/ayyub/"
+            folderUrl = "https://server11.mp3quran.net/mohna/"
         ),
         ReciterInfo(
             id = 256,
-            nameArabic = "عبد الله المطرود",
-            nameEnglish = "Abdullah Al-Matroud",
+            nameArabic = "أحمد خليل شاهين",
+            nameEnglish = "Ahmad Shaheen",
             rewaya = "حفص عن عاصم",
-            folderUrl = "https://server10.mp3quran.net/mat/"
+            folderUrl = "https://server16.mp3quran.net/shaheen/Rewayat-Hafs-A-n-Assem/"
         )
     )
 
@@ -193,7 +209,8 @@ internal object ReciterDataProvider {
     }
 
     /**
-     * Get default reciter (Abdul Basit)
+     * Get the default reciter: the lowest id we ship timing data for.
+     * Matches ReciterService.DEFAULT_RECITER_ID.
      */
     fun getDefaultReciter(): ReciterInfo {
         return allReciters.first()


### PR DESCRIPTION
## The bug

The library ships `assets/ayah_timing/read_<id>.json`. Each file carries **both** the per-ayah timings **and** the identity of the recitation they were measured against — name, rewaya, audio folder. `ReciterService` builds the live reciter list from those files.

`ReciterDataProvider` is a hardcoded second copy of that same data, used as a fallback. It had drifted from the assets **completely**:

```
names matching shipped data:  0/18
audio URLs matching:          0/18
```

It wasn't stale — it was *wrong*. Every id named a different reciter than the timing file with the same id, and pointed at that other reciter's audio:

| id | Shipped (truth) | Fallback claimed |
|---|---|---|
| 1 | Ibrahim Al-Akdar → `/akdr/` | Abdul Basit Abdul Samad → `/abas_64/` |
| 9 | Ahmad Nauina → `/ahmad_nu/` | Mahmoud Khalil Al-Hussary → `/husr/` |
| 118 | Mahmoud Khalil Al-Hussary → `/husr/` | Bandar Baleela → `/bnd/` |

So anything hitting the fallback would play one reciter while highlighting verses timed for another.

## Why it mattered more than it looked

This isn't only reachable when every asset fails to load. **`AudioRepository.getDefaultReciter()` is public API**, and it falls back to this table whenever the reciter list is empty — handing a consumer `id=1` labelled *"Abdul Basit"* pointing at `/abas_64/`, while `read_1.json` holds Al-Akdar's timings.

## The fix

The table is now **generated from the shipped timing files**, so it agrees with the assets by construction.

But correcting it once fixes nothing on its own — *nothing stopped it drifting in the first place*. So `ReciterFallbackMatchesShippedDataTest` reads the assets the way the library reads them (real `AssetManager`) and fails the build if the two ever disagree again. It asserts names, Arabic names, rewaya and audio URLs, plus that the default reciter is the lowest shipped id (which `ReciterService.DEFAULT_RECITER_ID` hardcodes as 1).

**I verified the guard fails on the old table** — both tests go red with `expected: Ibrahim Al-Akdar`. A guard nobody has seen fail isn't a guard.

## iOS has the same bug

The file claimed its data *"matches iOS implementation for compatibility"*. That was false in both directions. iOS has the identical design (builds from the JSON, falls back to a hardcoded catalog) and its catalog disagrees with the **same** shipped timing files on **16 of 18** ids. Reported separately — no Android change needed for it.

## Verified

- `apiCheck` clean — `ReciterDataProvider` is `internal`, no public API change
- unit tests + `:app:testSourceDebugUnitTest` pass
- `:mushaf-core:connectedDebugAndroidTest` — **19 tests, 0 failures** (17 existing + 2 new)

## Note

This touches `mushaf-core`, so **merging this will cut a real release (0.2.3)**: auto-bump → tag → JitPack → APK attached to the GitHub Release.