### PR TITLE
Unblock the release: make the instrumented suite deterministic, and keep the README's version honest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,12 @@ jobs:
           path: '**/build/reports/tests/'
 
   instrumented:
+    # Gated on `build`. The emulator jobs are by far the most expensive thing here -
+    # each boots an AVD and takes minutes - while `build` is cheap and catches the
+    # ordinary breakages (API change, failing unit test, compile error). Running them
+    # in parallel meant a one-line apiCheck failure still paid for two emulator boots.
+    # Costs a little wall-clock on a green run; saves a lot of minutes on a red one.
+    needs: build
     if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')
     runs-on: ubuntu-latest
     steps:
@@ -128,12 +134,11 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
           disable-animations: true
-          # Wake and unlock before running. Compose's performClick injects real
-          # touch events, and the injection is REJECTED outright - "Failed to
-          # inject touch input" - if the emulator is asleep or sitting behind the
-          # keyguard, which a freshly booted headless AVD often is. That is an
-          # environment problem, so it is fixed here rather than by weakening the
-          # test to stop touching the screen.
+          # Wake and unlock before running: a freshly booted headless AVD is often
+          # still asleep or behind the keyguard, and an app cannot be driven in that
+          # state. This is hygiene, not a fix - it did NOT stop the "Failed to inject
+          # touch input" flake, which is why MushafViewRestoreTest no longer depends
+          # on the emulator's touch-injection stack (see the comment there).
           script: |
             adb shell input keyevent 82 || true
             adb shell wm dismiss-keyguard || true
@@ -148,6 +153,8 @@ jobs:
           path: '**/build/reports/androidTests/'
 
   consumer:
+    # Same gate as `instrumented`, for the same reason.
+    needs: build
     if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,10 +167,32 @@ jobs:
           if [ "$BUMP_NEEDED" = true ]; then
             sed -i "s/^VERSION_NAME=.*/VERSION_NAME=${RELEASE_VERSION}/" gradle.properties
             sed -i "s/^VERSION_CODE=.*/VERSION_CODE=${NEW_CODE}/" gradle.properties
+          fi
 
+          # Point the README at the version we are about to publish. The dependency
+          # snippet is the single most consequential line in it - people copy-paste it -
+          # and until now nothing updated it, so every release quietly told new users to
+          # depend on the previous one.
+          #
+          # These patterns are deliberately narrow. A blanket search-and-replace of the
+          # old version string would also rewrite the "## What's new in 0.2.2" heading
+          # and the prose describing what past releases fixed, i.e. it would falsify the
+          # changelog. Only what must track the current version is touched; history is
+          # left alone.
+          sed -i -E "s|mushaf-ui:[0-9]+\.[0-9]+\.[0-9]+|mushaf-ui:${RELEASE_VERSION}|g" README.md
+          sed -i -E "s|mushaf-core:[0-9]+\.[0-9]+\.[0-9]+|mushaf-core:${RELEASE_VERSION}|g" README.md
+          sed -i -E "s|Version-[0-9]+\.[0-9]+\.[0-9]+-blue|Version-${RELEASE_VERSION}-blue|g" README.md
+          sed -i -E "s|(releases/tag/)[0-9]+\.[0-9]+\.[0-9]+|\1${RELEASE_VERSION}|g" README.md
+          sed -i -E "s|^\*\*Version:\*\* [0-9]+\.[0-9]+\.[0-9]+|**Version:** ${RELEASE_VERSION}|" README.md
+          sed -i -E "s|^\*\*Current Version:\*\* [0-9]+\.[0-9]+\.[0-9]+|**Current Version:** ${RELEASE_VERSION}|" README.md
+
+          # One commit for the whole release: the version bump (if any) and the docs that
+          # quote it. Committing only when something actually changed keeps a re-run or a
+          # deliberate human bump from creating an empty commit.
+          if ! git diff --quiet gradle.properties README.md; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add gradle.properties
+            git add gradle.properties README.md
             git commit -m "chore: release ${RELEASE_VERSION} [skip ci]"
             git push origin HEAD:main
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 .cxx
 local.properties
 .claude/
+
+# Android Studio creates a nested .idea/ inside each module (e.g. app/.idea/).
+# Unanchored so it matches at any depth, not just the repo root.
+.idea/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Quran reader library for Android providing high-quality Mushaf page display wi
 [![Android](https://img.shields.io/badge/Platform-Android-green.svg)](https://android.com)
 [![API](https://img.shields.io/badge/API-24%2B-brightgreen.svg)](https://android-arsenal.com/api?level=24)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.0.21-blue.svg)](https://kotlinlang.org)
-[![Version](https://img.shields.io/badge/Version-0.2.2-blue.svg)](https://github.com/YahiaRagae/mushaf-imad-android/releases/tag/0.2.2)
+[![Version](https://img.shields.io/badge/Version-0.2.3-blue.svg)](https://github.com/YahiaRagae/mushaf-imad-android/releases/tag/0.2.3)
 [![JitPack](https://jitpack.io/v/YahiaRagae/mushaf-imad-android.svg)](https://jitpack.io/#YahiaRagae/mushaf-imad-android)
 [![Status](https://img.shields.io/badge/Status-Stable-green.svg)](https://github.com/YahiaRagae/mushaf-imad-android)
 
@@ -59,14 +59,14 @@ Then add the dependency in your app's `build.gradle.kts`:
 **Option A: Full library (UI + Data) — recommended**
 ```kotlin
 dependencies {
-    implementation("com.github.YahiaRagae.mushaf-imad-android:mushaf-ui:0.2.2")
+    implementation("com.github.YahiaRagae.mushaf-imad-android:mushaf-ui:0.2.3")
 }
 ```
 
 **Option B: Data layer only (custom UI)**
 ```kotlin
 dependencies {
-    implementation("com.github.YahiaRagae.mushaf-imad-android:mushaf-core:0.2.2")
+    implementation("com.github.YahiaRagae.mushaf-imad-android:mushaf-core:0.2.3")
 }
 ```
 
@@ -419,7 +419,7 @@ in two product flavours against two different spellings of the same library:
 
 ## Project Status
 
-**Version:** 0.2.2
+**Version:** 0.2.3
 **Status:** Published on [JitPack](https://jitpack.io/#YahiaRagae/mushaf-imad-android)
 
 ---
@@ -546,6 +546,6 @@ Developed with care for the Muslim community.
 ---
 
 **Last Updated:** July 2026
-**Current Version:** 0.2.2
+**Current Version:** 0.2.3
 **Status:** Stable - Production Ready
 **Published:** [JitPack](https://jitpack.io/#YahiaRagae/mushaf-imad-android)

--- a/mushaf-ui/src/androidTest/java/com/mushafimad/ui/mushaf/MushafViewRestoreTest.kt
+++ b/mushaf-ui/src/androidTest/java/com/mushafimad/ui/mushaf/MushafViewRestoreTest.kt
@@ -1,9 +1,12 @@
 package com.mushafimad.ui.mushaf
 
 import androidx.activity.ComponentActivity
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
-import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.mushafimad.core.MushafLibrary
@@ -120,8 +123,22 @@ class MushafViewRestoreTest {
         }
         compose.waitUntil(timeoutMillis = 15_000) { pageShown == 100 }
 
-        // Tap "next page" and let the debounced save run
-        compose.onNodeWithContentDescription("الصفحة التالية").performClick()
+        // Tap "next page" and let the debounced save run.
+        //
+        // Deliberately not performClick(). performClick does two things: it checks the
+        // node is displayed and clickable, then injects a real touch event. On a
+        // headless CI emulator that injection is rejected outright - "Failed to inject
+        // touch input" - which fails the build for reasons that have nothing to do with
+        // this library. Waking and unlocking the device first did not fix it.
+        //
+        // The check is the part worth keeping, so it is kept, explicitly. The injection
+        // is not: it was only ever exercising the emulator's input stack. Driving the
+        // click through the semantics action asserts the same thing about the button and
+        // then invokes it deterministically.
+        compose.onNodeWithContentDescription("الصفحة التالية")
+            .assertIsDisplayed()
+            .assertHasClickAction()
+            .performSemanticsAction(SemanticsActions.OnClick)
         compose.waitUntil(timeoutMillis = 15_000) { pageShown == 101 }
         compose.waitUntil(timeoutMillis = 15_000) {
             runBlocking {


### PR DESCRIPTION
## Why now

The 0.2.3 release is **blocked**. Its CI gate failed on `instrumented`, so `release` was skipped — no bump, no tag, nothing published. That is the pipeline working: because the tag is only pushed *after* the gate passes, **0.2.3 was not burned** on JitPack and is still available.

The failure was not a real one.

## 1. The flake, properly fixed this time

```
MushafViewRestoreTest > navigatingWritesTheNewPosition
java.lang.AssertionError: Failed to inject touch input.
```

Re-running the identical commit passed, so it is a runner flake. My previous attempt — waking and unlocking the emulator before the tests — **did not work**; it failed again the same way. That comment in `ci.yml` claimed a fix it never delivered and is now corrected to say what it actually is (hygiene, not a fix).

The real answer is to look at what `performClick()` does. It does **two** things:
1. asserts the node is displayed and clickable, then
2. injects a real touch event.

Only (1) tests this library. (2) was testing GitHub's software-rendered emulator, which rejects the injection often enough to break the build for reasons that have nothing to do with us.

So (1) is **kept, explicitly** — `assertIsDisplayed()`, `assertHasClickAction()` — and the click is driven through the semantics action:

```kotlin
compose.onNodeWithContentDescription("الصفحة التالية")
    .assertIsDisplayed()
    .assertHasClickAction()
    .performSemanticsAction(SemanticsActions.OnClick)
```

The test asserts everything about that button it asserted before, and no longer depends on an input stack we don't ship. **This is not an assertion weakened to buy a green tick** — the weak version would have been to drop the display/clickable assertions and quietly stop proving the button is reachable at all. That's the opposite of what this does.

## 2. Don't burn emulator minutes on a red build

`build`, `instrumented` and `consumer` all ran **in parallel**, so a one-line `apiCheck` failure still paid for two AVD boots. The emulator jobs now `needs: build` — cheap gate first, expensive gate only if it passes. Costs a little wall-clock on a green run, saves a lot of minutes on a red one.

## 3. The README was about to lie to every new user

Nothing updated it on release. The moment 0.2.3 shipped, the copy-paste dependency snippet would still have said **0.2.2** — and that snippet is the single most consequential line in the file.

The release job now rewrites the coordinates and the version badges in the same commit as the version bump. The patterns are **deliberately narrow**: a blanket search-and-replace of the old version string would also rewrite `## What's new in 0.2.2` and the prose describing what past releases fixed — i.e. it would falsify the changelog. Only what must track the current version is touched; history is left alone. Verified locally: 5 lines change, the changelog headings don't.

## 4. `.idea/` at any depth

Android Studio creates `app/.idea/` now that `:app` exists.

## Verified

- `MushafViewRestoreTest` — 5 tests, 0 failures, on-device
- `actionlint` + YAML valid on both workflows
- README patterns verified to leave `## What's new in 0.2.2` untouched

Merging this touches `mushaf-ui`, so it will cut **0.2.3** — which is what we were trying to release in the first place.