### PR TITLE
Fix oversized verse-number markers overlapping the text (#85)

### DIFF
--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranLineImageView.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranLineImageView.kt
@@ -147,16 +147,15 @@ fun QuranLineImageView(
                 val markerX = containerWidth * (1.0f - marker.centerX)
                 val markerY = containerHeight * marker.centerY
 
-                // Marker size calculation (increased from quran_android's 5% for better readability)
-                // quran_android uses: markerDimen = (0.025f * 2 * width).toInt() = 5%
-                // We use 7% for better visibility and readability
-                val markerDimen = (0.035f * 2 * containerWidth).toInt()
+                // Marker WIDTH = 5.4% of the line width - the width of the blank slot the
+                // Mushaf reserves for the verse number. The height follows the ornament's
+                // taller-than-wide aspect (see VerseFasel), so the number stays readable
+                // without the marker spilling sideways onto the text. Mirrors the iOS renderer.
+                val markerWidth = 0.054f * containerWidth
+                val markerHeight = markerWidth / (92f / 117f)
 
-                // Center the marker at coordinates (quran_android approach)
-                // x = points[0] - (markerDimen / 2) + paddingLeft
-                // Note: we don't have padding in our Compose setup
-                val adjustedX = markerX - (markerDimen / 2f)
-                val adjustedY = markerY - (markerDimen / 2f)
+                val adjustedX = markerX - (markerWidth / 2f)
+                val adjustedY = markerY - (markerHeight / 2f)
 
                 Box(
                     modifier = Modifier
@@ -167,7 +166,7 @@ fun QuranLineImageView(
                 ) {
                     VerseFasel(
                         number = verse.number,
-                        sizeInPx = markerDimen.toFloat()
+                        sizeInPx = markerWidth
                     )
                 }
             }

--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/VerseFasel.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/VerseFasel.kt
@@ -36,47 +36,41 @@ fun VerseFasel(
 ) {
     val density = LocalDensity.current
 
-    // Base dimensions for marker sizing and font scaling
-    val baseFontSize = 18f
-    val balance = 1.2f
-    val baseWidth = 21 * balance
+    // The fasel ornament is taller than it is wide (native 92x117). iOS renders it at
+    // that aspect so the marker fits the narrow slot the Mushaf reserves for the number
+    // (its width) while staying tall enough to read (its height). Rendering it square, as
+    // before, forced a bad choice: wide enough to read meant spilling onto the adjacent
+    // letter; narrow enough not to spill meant it was too small.
+    val ornamentWtoH = 92f / 117f
 
-    // Calculate size: either use provided sizeInPx or fallback to scale-based calculation
-    val finalSize = sizeInPx?.let { px ->
-        with(density) { px.toDp() }
-    } ?: run {
-        (baseWidth * scale).dp
-    }
-
-    // Calculate effective scale for font sizing
-    val effectiveScale = sizeInPx?.let { px ->
-        with(density) {
-            px.toDp().value / baseWidth
-        }
-    } ?: scale
+    // sizeInPx, when provided, is the target WIDTH in px; the height follows the aspect.
+    val widthDp = sizeInPx?.let { px -> with(density) { px.toDp() } } ?: (21 * 1.2f * scale).dp
+    val heightDp = widthDp / ornamentWtoH
+    val fontSizeSp = with(density) { (heightDp.toPx() * 0.46f).toSp() }
 
     Box(
-        modifier = modifier.size(finalSize),
+        modifier = modifier
+            .width(widthDp)
+            .height(heightDp),
         contentAlignment = Alignment.Center
     ) {
-        // Decorative ornamental background
+        // Decorative ornamental background, stretched to the ornament's own aspect
         Image(
             painter = painterResource(id = R.drawable.fasel),
             contentDescription = null,
             modifier = Modifier.fillMaxSize(),
-            contentScale = ContentScale.Fit
+            contentScale = ContentScale.FillBounds
         )
 
         Text(
             text = convertToArabicNumerals(number),
-            fontSize = (baseFontSize * effectiveScale * 0.6f).sp,
+            fontSize = fontSizeSp,
             fontFamily = QuranFonts.UthmanTaha,
             fontWeight = FontWeight.Bold,
             color = Color.Black,
             textAlign = TextAlign.Center,
-            modifier = Modifier.offset(
-                y = (1 * effectiveScale).dp,
-            )
+            maxLines = 1,
+            softWrap = false
         )
     }
 }


### PR DESCRIPTION
Fixes #85.

## Problem
Verse-number markers were drawn ~34% larger than the gap the Mushaf reserves for them, so each number overflowed onto the adjacent letter and end-of-line markers clipped at the margin.

## Root cause: shape, not just size
`VerseFasel` rendered the `fasel` ornament — natively **92×117, taller than wide** — inside a **square** `Box`, and sized it as a flat percentage of the line width. A square can't win: wide enough to read means spilling onto the text; narrow enough not to spill means too small. (The naive 7% → 5% change just traded one problem for the other.)

## Fix
Render it the way iOS does: at the ornament's own tall aspect, with the **width sized to the reserved slot (~5.4%)** and the **height following from the aspect (~6.9%)**. The number scales with the taller height, so it stays readable while the marker no longer spills sideways.

- `VerseFasel.kt` — renders at the tall aspect; `sizeInPx` now denotes width, height derived from 92:117.
- `QuranLineImageView.kt` — sizes the marker to width 5.4% / height ~6.9% and centres it, mirroring iOS's `lineScale`.

## Verification
- Compared against a **live iOS render of the same page (286)** from the Simulator — the Android result matches.
- `apiCheck` green — `VerseFasel`'s public signature is unchanged, so no `apiDump` needed.
- `:mushaf-ui:connectedDebugAndroidTest` — 6 tests pass on API 33 and API 37.

Targets the `release/0.3.0` branch.