### PR TITLE
Long-press verse selection + whole-verse press preview (#86, #87)

### DIFF
--- a/app/src/main/java/com/mushafimad/app/ui/reader/ReaderScreen.kt
+++ b/app/src/main/java/com/mushafimad/app/ui/reader/ReaderScreen.kt
@@ -100,7 +100,8 @@ fun ReaderScreen(
                         showNavigationControls = true,
                         showPageInfo = true,
                         showAudioPlayer = true,
-                        onVerseSelected = viewModel::toggleBookmark,
+                        onVerseSelected = viewModel::onVerseTapped,
+                        onVerseLongPress = viewModel::toggleBookmark,
                         onPageChanged = viewModel::onPageChanged,
                         modifier = Modifier.fillMaxSize()
                     )
@@ -112,7 +113,8 @@ fun ReaderScreen(
                         initialPage = start.page,
                         showNavigationControls = true,
                         showPageInfo = true,
-                        onVerseSelected = viewModel::toggleBookmark,
+                        onVerseSelected = viewModel::onVerseTapped,
+                        onVerseLongPress = viewModel::toggleBookmark,
                         onPageChanged = viewModel::onPageChanged,
                         modifier = Modifier.fillMaxSize()
                     )

--- a/app/src/main/java/com/mushafimad/app/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/com/mushafimad/app/ui/reader/ReaderViewModel.kt
@@ -92,7 +92,16 @@ class ReaderViewModel : ViewModel() {
         }
     }
 
-    /** Bookmarks come from the library's BookmarkRepository. */
+    /**
+     * A single tap just reports which verse was tapped - it is bookmarking that now lives
+     * on long-press (see the reader wiring), so an accidental tap no longer toggles a
+     * bookmark. This shows off the library exposing tap and long-press as separate hooks.
+     */
+    fun onVerseTapped(verse: Verse) {
+        showMessage("Tapped ${verse.chapterNumber}:${verse.number}")
+    }
+
+    /** Bookmarks come from the library's BookmarkRepository. Now driven by long-press. */
     fun toggleBookmark(verse: Verse) {
         viewModelScope.launch {
             val existing = bookmarkRepository.getBookmarkForVerse(verse.chapterNumber, verse.number)

--- a/mushaf-ui/api/mushaf-ui.api
+++ b/mushaf-ui/api/mushaf-ui.api
@@ -164,7 +164,7 @@ public final class com/mushafimad/ui/mushaf/MushafUiState {
 }
 
 public final class com/mushafimad/ui/mushaf/MushafViewKt {
-	public static final fun MushafView (Lcom/mushafimad/ui/theme/ReadingTheme;Lcom/mushafimad/ui/theme/ColorSchemeType;Lcom/mushafimad/core/domain/models/MushafType;Ljava/lang/Integer;Lcom/mushafimad/core/domain/models/Verse;ZZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Lcom/mushafimad/ui/mushaf/MushafViewModel;Landroidx/compose/runtime/Composer;III)V
+	public static final fun MushafView (Lcom/mushafimad/ui/theme/ReadingTheme;Lcom/mushafimad/ui/theme/ColorSchemeType;Lcom/mushafimad/core/domain/models/MushafType;Ljava/lang/Integer;Lcom/mushafimad/core/domain/models/Verse;ZZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Lcom/mushafimad/ui/mushaf/MushafViewModel;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class com/mushafimad/ui/mushaf/MushafViewModel : androidx/lifecycle/ViewModel {
@@ -191,7 +191,7 @@ public final class com/mushafimad/ui/mushaf/MushafViewModel : androidx/lifecycle
 }
 
 public final class com/mushafimad/ui/mushaf/MushafWithPlayerViewKt {
-	public static final fun MushafWithPlayerView (Lcom/mushafimad/ui/theme/ReadingTheme;Lcom/mushafimad/ui/theme/ColorSchemeType;Lcom/mushafimad/core/domain/models/MushafType;Ljava/lang/Integer;ZZZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final fun MushafWithPlayerView (Lcom/mushafimad/ui/theme/ReadingTheme;Lcom/mushafimad/ui/theme/ColorSchemeType;Lcom/mushafimad/core/domain/models/MushafType;Ljava/lang/Integer;ZZZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class com/mushafimad/ui/mushaf/PageInfo {
@@ -215,11 +215,11 @@ public final class com/mushafimad/ui/mushaf/PageInfo {
 }
 
 public final class com/mushafimad/ui/mushaf/QuranLineImageViewKt {
-	public static final fun QuranLineImageView (IILcom/mushafimad/core/domain/models/MushafType;Ljava/util/List;Lcom/mushafimad/core/domain/models/Verse;Lcom/mushafimad/core/domain/models/Verse;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final fun QuranLineImageView (IILcom/mushafimad/core/domain/models/MushafType;Ljava/util/List;Lcom/mushafimad/core/domain/models/Verse;Lcom/mushafimad/core/domain/models/Verse;Lcom/mushafimad/core/domain/models/Verse;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class com/mushafimad/ui/mushaf/QuranPageViewKt {
-	public static final fun QuranPageView (Ljava/util/List;Ljava/util/List;IILcom/mushafimad/core/domain/models/MushafType;Lcom/mushafimad/core/domain/models/Verse;Lcom/mushafimad/core/domain/models/Verse;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final fun QuranPageView (Ljava/util/List;Ljava/util/List;IILcom/mushafimad/core/domain/models/MushafType;Lcom/mushafimad/core/domain/models/Verse;Lcom/mushafimad/core/domain/models/Verse;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mushafimad/ui/mushaf/VerseFaselKt {

--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/MushafView.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/MushafView.kt
@@ -62,6 +62,7 @@ fun MushafView(
     showNavigationControls: Boolean = true,
     showPageInfo: Boolean = true,
     onVerseSelected: ((Verse) -> Unit)? = null,
+    onVerseLongPress: ((Verse) -> Unit)? = null,
     onPageChanged: ((Int) -> Unit)? = null,
     modifier: Modifier = Modifier,
     viewModel: MushafViewModel = mushafViewModel()
@@ -160,6 +161,7 @@ fun MushafView(
                                 viewModel.selectVerse(verse)
                                 onVerseSelected?.invoke(verse)
                             },
+                            onVerseLongClick = onVerseLongPress,
                             viewModel = viewModel
                         )
                     }
@@ -208,6 +210,7 @@ private fun MushafPagerPage(
     selectedVerse: Verse?,
     highlightedVerse: Verse?,
     onVerseClick: (Verse) -> Unit,
+    onVerseLongClick: ((Verse) -> Unit)? = null,
     viewModel: MushafViewModel,
     modifier: Modifier = Modifier
 ) {
@@ -232,6 +235,7 @@ private fun MushafPagerPage(
             selectedVerse = selectedVerse,
             highlightedVerse = highlightedVerse,
             onVerseClick = onVerseClick,
+            onVerseLongClick = onVerseLongClick,
             modifier = modifier.fillMaxSize()
         )
     } else {

--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/MushafWithPlayerView.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/MushafWithPlayerView.kt
@@ -43,6 +43,7 @@ fun MushafWithPlayerView(
     showPageInfo: Boolean = true,
     showAudioPlayer: Boolean = true,
     onVerseSelected: ((Verse) -> Unit)? = null,
+    onVerseLongPress: ((Verse) -> Unit)? = null,
     onPageChanged: ((Int) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
@@ -145,6 +146,7 @@ fun MushafWithPlayerView(
                 showNavigationControls = showNavigationControls,
                 showPageInfo = showPageInfo,
                 onVerseSelected = onVerseSelected,
+                onVerseLongPress = onVerseLongPress,
                 onPageChanged = onPageChangedStable,
                 viewModel = mushafViewModel
             )

--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranLineImageView.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranLineImageView.kt
@@ -2,9 +2,12 @@ package com.mushafimad.ui.mushaf
 
 import android.content.Context
 import android.graphics.BitmapFactory
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -34,6 +37,7 @@ import java.io.InputStream
  * Original dimensions: 1440 x 232 pixels
  * Each page has 15 lines (0-14)
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun QuranLineImageView(
     page: Int,
@@ -42,7 +46,10 @@ fun QuranLineImageView(
     verses: List<Verse>,
     selectedVerse: Verse? = null,
     highlightedVerse: Verse? = null,
+    pressedVerse: Verse? = null,
     onVerseClick: ((Verse) -> Unit)? = null,
+    onVerseLongClick: ((Verse) -> Unit)? = null,
+    onVersePressChange: ((Verse?) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -101,8 +108,27 @@ fun QuranLineImageView(
                     val highlightWidth = visualRightX - visualLeftX
                     val highlightHeight = containerHeight * 0.94f
 
-                    // Determine if this verse should be highlighted
-                    val shouldHighlight = verse == selectedVerse || verse == highlightedVerse
+                    // The committed selection, the audio highlight, and the transient
+                    // press preview all paint the same way. pressedVerse makes the WHOLE
+                    // verse light up while a finger is down on any one of its fragments
+                    // (matching iOS), instead of a per-fragment ripple on one line only.
+                    val shouldHighlight =
+                        verse == selectedVerse || verse == highlightedVerse || verse == pressedVerse
+
+                    // Report press down/up for this fragment up to the page, which shares
+                    // one pressedVerse across all lines so every fragment reacts together.
+                    val interactionSource = remember { MutableInteractionSource() }
+                    val isPressed by interactionSource.collectIsPressedAsState()
+                    LaunchedEffect(isPressed) {
+                        onVersePressChange?.invoke(if (isPressed) verse else null)
+                    }
+                    // If this fragment leaves composition while still pressed - e.g. the page
+                    // scrolls out from under the finger - the effect above is cancelled without
+                    // ever reporting the release, which would leave the preview stuck on a verse
+                    // that scrolled away. Clear it on disposal to guarantee it never sticks.
+                    DisposableEffect(Unit) {
+                        onDispose { if (isPressed) onVersePressChange?.invoke(null) }
+                    }
 
                     Box(
                         modifier = Modifier
@@ -126,9 +152,14 @@ fun QuranLineImageView(
                                     androidx.compose.ui.graphics.Color.Transparent
                                 }
                             )
-                            .clickable(enabled = onVerseClick != null) {
-                                onVerseClick?.invoke(verse)
-                            }
+                            .combinedClickable(
+                                interactionSource = interactionSource,
+                                // No ripple: the whole-verse background flip IS the feedback.
+                                indication = null,
+                                enabled = onVerseClick != null || onVerseLongClick != null,
+                                onClick = { onVerseClick?.invoke(verse) },
+                                onLongClick = onVerseLongClick?.let { cb -> { cb(verse) } }
+                            )
                     )
                 }
             }

--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranPageView.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranPageView.kt
@@ -48,8 +48,12 @@ fun QuranPageView(
     selectedVerse: Verse? = null,
     highlightedVerse: Verse? = null,
     onVerseClick: ((Verse) -> Unit)? = null,
+    onVerseLongClick: ((Verse) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
+    // One press-preview verse shared across all 15 line views on this page, so pressing
+    // any fragment lights up every fragment of that verse. Resets when the page changes.
+    var pressedVerse by remember { mutableStateOf<Verse?>(null) }
     val readingTheme = MaterialTheme.readingTheme
     val configuration = LocalConfiguration.current
     val density = LocalDensity.current
@@ -94,7 +98,10 @@ fun QuranPageView(
                         verses = verses.filter { it.pageNumber == pageNumber },
                         selectedVerse = selectedVerse,
                         highlightedVerse = highlightedVerse,
+                        pressedVerse = pressedVerse,
                         onVerseClick = onVerseClick,
+                        onVerseLongClick = onVerseLongClick,
+                        onVersePressChange = { pressedVerse = it },
                         modifier = Modifier.fillMaxWidth()
                     )
                 }


### PR DESCRIPTION
Closes #86. Closes #87.

## What
The library exposed only a **tap** for verse selection; iOS uses a **long-press**. This adds long-press *alongside* tap so a consumer can use either — and makes the whole verse light up while pressing, matching iOS.

### Library (#86)
- `MushafView` / `MushafWithPlayerView` gain `onVerseLongPress`; `onVerseSelected` (tap) is unchanged. Verses use `combinedClickable` for tap + long-press.
- **Whole-verse press preview:** while a verse is pressed, every line-fragment of it highlights (a shared `pressedVerse` in `QuranPageView`, OR-ed into the highlight), instead of a per-fragment ripple on one line. Reuses the exact selection colour, so it's indistinguishable from a committed selection.
- **Disposal-safe clear:** if a pressed fragment scrolls out from under the finger, its release is never reported — so it's also cleared on disposal. The preview can never stick to a verse that scrolled away.
- New params are defaulted → the frozen **v0.1 fixture still compiles**; `apiDump` regenerated for the additive API change.

### Demo app (#87)
- Tap now shows a toast; **long-press bookmarks**. An accidental tap no longer toggles a bookmark, and the demo now exercises both library callbacks.

## Verified (on-device, API 33 + 37)
- Tap → reports exactly one verse + toast (the earlier "two verses" was `adb` synthetic-input noise, not a bug — confirmed with a real tap).
- Long-press → bookmarks, **no stuck highlight** after release.
- `mushaf-ui` instrumented regression suite passes.
- `apiCheck` green with the regenerated dump; v0.1 fixture compiles.

Before/after screenshots attached in a comment.

Targets `release/0.3.0`.