### PR TITLE
Fit the page to the screen + full-screen immersive reader (#94)

### DIFF
--- a/app/src/main/java/com/mushafimad/app/ui/reader/ReaderScreen.kt
+++ b/app/src/main/java/com/mushafimad/app/ui/reader/ReaderScreen.kt
@@ -1,13 +1,16 @@
 package com.mushafimad.app.ui.reader
 
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Headphones
@@ -23,6 +26,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -31,6 +35,10 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.mushafimad.app.ui.AppSettings
@@ -54,11 +62,34 @@ fun ReaderScreen(
     var withPlayer by rememberSaveable { mutableStateOf(startWithPlayer) }
     val snackbar = remember { SnackbarHostState() }
 
-    // Immersive reading, matching the iOS viewer: the app bar is hidden so the page opens
-    // clean (just the surah/juz header, the text and the page ornament). A tap on the page
-    // (onPageTap) brings the bar back for navigation and the player toggle; tap again to
-    // hide it. The system status bar stays put, exactly as iOS keeps it.
+    // `immersive` toggles ONLY the floating in-app top bar (below). It does NOT touch the
+    // system bars: those stay hidden the whole time the reader is open (see the effect
+    // below), so revealing the toolbar never resizes or pushes the page.
     var immersive by remember { mutableStateOf(true) }
+
+    // Keep the system status/navigation bars hidden for the entire time the reader is on
+    // screen, so the page uses the full display and never reflows. Transient-by-swipe
+    // behaviour means the user can still peek the bars with an edge swipe, and because a
+    // transient bar is drawn as an overlay it does not consume insets - the page stays put.
+    // The bars are restored when leaving the reader, so the rest of the app is never left
+    // in full-screen mode.
+    val view = LocalView.current
+    DisposableEffect(view) {
+        val window = view.context.findActivity()?.window
+        if (window != null) {
+            val controller = WindowCompat.getInsetsController(window, view)
+            controller.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            controller.hide(WindowInsetsCompat.Type.systemBars())
+        }
+        onDispose {
+            val w = view.context.findActivity()?.window
+            if (w != null) {
+                WindowCompat.getInsetsController(w, view)
+                    .show(WindowInsetsCompat.Type.systemBars())
+            }
+        }
+    }
 
     LaunchedEffect(chapterNumber, requestedPage) {
         viewModel.resolveStart(chapterNumber, requestedPage)
@@ -72,13 +103,65 @@ fun ReaderScreen(
 
     Scaffold(
         snackbarHost = { SnackbarHost(snackbar) },
-        topBar = {
+        // The parent QuranApp Scaffold already insets this screen for the status and
+        // navigation bars, so this inner Scaffold must NOT inset again - doing so doubled
+        // the status-bar gap at the top of the page. Consume no insets here.
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
+    ) { _ ->
+        Box(Modifier.fillMaxSize()) {
+            // The reader fills the area the parent already inset for us. Its position never
+            // depends on whether the app bar is showing: the bar floats over the reader
+            // (see below) instead of pushing it down, so the page never jumps on toggle.
+            Box(Modifier.fillMaxSize()) {
+                when (val start = state.startPage) {
+                    StartPage.Resolving -> CircularProgressIndicator(Modifier.align(Alignment.Center))
+
+                    is StartPage.Ready -> if (withPlayer) {
+                        // Reader + audio. The player's reciter chip opens the library's
+                        // ReciterPickerDialog internally.
+                        MushafWithPlayerView(
+                            readingTheme = readingTheme,
+                            colorScheme = colorScheme,
+                            mushafType = mushafType,
+                            initialPage = start.page,
+                            showNavigationControls = false,
+                            showAudioPlayer = true,
+                            onVerseSelected = viewModel::onVerseTapped,
+                            onVerseLongPress = viewModel::toggleBookmark,
+                            onPageTap = { immersive = !immersive },
+                            onPageChanged = viewModel::onPageChanged,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    } else {
+                        MushafView(
+                            readingTheme = readingTheme,
+                            colorScheme = colorScheme,
+                            mushafType = mushafType,
+                            initialPage = start.page,
+                            showNavigationControls = false,
+                            onVerseSelected = viewModel::onVerseTapped,
+                            onVerseLongPress = viewModel::toggleBookmark,
+                            onPageTap = { immersive = !immersive },
+                            onPageChanged = viewModel::onPageChanged,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    }
+                }
+            }
+
+            // App bar OVERLAYS the top edge, drawn on top of the reader's own header.
+            // Showing/hiding it animates the bar in and out without moving the page
+            // underneath, matching the reader UX where the chrome floats over the page.
             AnimatedVisibility(
                 visible = !immersive,
                 enter = slideInVertically { -it } + fadeIn(),
                 exit = slideOutVertically { -it } + fadeOut(),
+                modifier = Modifier.align(Alignment.TopCenter),
             ) {
                 TopAppBar(
+                    // Already positioned below the status bar by the parent inset, so the
+                    // bar itself adds no top inset (otherwise it floats with a gap above it).
+                    windowInsets = WindowInsets(0, 0, 0, 0),
                     title = {
                         Text(
                             state.title + (state.currentPage?.let { " - p.$it" } ?: ""),
@@ -101,42 +184,12 @@ fun ReaderScreen(
                 )
             }
         }
-    ) { padding ->
-        Box(Modifier.fillMaxSize().padding(padding)) {
-            when (val start = state.startPage) {
-                StartPage.Resolving -> CircularProgressIndicator(Modifier.align(Alignment.Center))
-
-                is StartPage.Ready -> if (withPlayer) {
-                    // Reader + audio. The player's reciter chip opens the library's
-                    // ReciterPickerDialog internally.
-                    MushafWithPlayerView(
-                        readingTheme = readingTheme,
-                        colorScheme = colorScheme,
-                        mushafType = mushafType,
-                        initialPage = start.page,
-                        showNavigationControls = false,
-                        showAudioPlayer = true,
-                        onVerseSelected = viewModel::onVerseTapped,
-                        onVerseLongPress = viewModel::toggleBookmark,
-                        onPageTap = { immersive = !immersive },
-                        onPageChanged = viewModel::onPageChanged,
-                        modifier = Modifier.fillMaxSize()
-                    )
-                } else {
-                    MushafView(
-                        readingTheme = readingTheme,
-                        colorScheme = colorScheme,
-                        mushafType = mushafType,
-                        initialPage = start.page,
-                        showNavigationControls = false,
-                        onVerseSelected = viewModel::onVerseTapped,
-                        onVerseLongPress = viewModel::toggleBookmark,
-                        onPageTap = { immersive = !immersive },
-                        onPageChanged = viewModel::onPageChanged,
-                        modifier = Modifier.fillMaxSize()
-                    )
-                }
-            }
-        }
     }
+}
+
+/** Walk up the Context wrappers to the hosting Activity (whose window we toggle). */
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
 }

--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranLineImageView.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranLineImageView.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
@@ -72,8 +73,7 @@ fun QuranLineImageView(
 
     Box(
         modifier = modifier
-            .fillMaxWidth()
-            .aspectRatio(imageAspect)
+            .clipToBounds()
             .onGloballyPositioned { coordinates ->
                 with(density) {
                     containerWidth = coordinates.size.width.toFloat()
@@ -86,7 +86,11 @@ fun QuranLineImageView(
             Image(
                 bitmap = bitmap,
                 contentDescription = "Quran page $page line $line",
-                contentScale = ContentScale.Fit,
+                // Fill the width and crop the image's top/bottom whitespace: the line frame
+                // is deliberately shorter than the image's natural height so 15 lines fit the
+                // screen, and cropping (not scaling) keeps the glyphs full-size and tightens
+                // line spacing, exactly as the iOS viewer does.
+                contentScale = ContentScale.Crop,
                 colorFilter = ColorFilter.tint(readingTheme.textColor),
                 modifier = Modifier.fillMaxSize()
             )
@@ -174,9 +178,15 @@ fun QuranLineImageView(
 
             // Markers use 0-14 indexing like highlights, adjust for UI's 1-15
             if (marker != null && marker.line == (line - 1) && containerWidth > 0f && containerHeight > 0f) {
-                // Transform percentage coordinates to screen pixels (RTL-aware for X)
+                // Transform percentage coordinates to screen pixels (RTL-aware for X).
+                // The line frame is shorter than the image's natural height (the page fits
+                // 15 lines to the screen and the image is cropped top/bottom), so the marker
+                // centerY - given relative to the FULL image - is mapped into full-image
+                // space and shifted up by the crop offset. Mirrors the iOS renderer.
+                val scaledImageHeight = containerWidth / imageAspect
+                val cropOffset = (scaledImageHeight - containerHeight) / 2f
                 val markerX = containerWidth * (1.0f - marker.centerX)
-                val markerY = containerHeight * marker.centerY
+                val markerY = scaledImageHeight * marker.centerY - cropOffset
 
                 // Marker WIDTH = 5.4% of the line width - the width of the blank slot the
                 // Mushaf reserves for the verse number. The height follows the ornament's

--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranPageView.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranPageView.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -13,11 +11,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.Font
@@ -67,12 +63,6 @@ fun QuranPageView(
     // any fragment lights up every fragment of that verse. Resets when the page changes.
     var pressedVerse by remember { mutableStateOf<Verse?>(null) }
     val readingTheme = MaterialTheme.readingTheme
-    val configuration = LocalConfiguration.current
-    val density = LocalDensity.current
-
-    // Calculate dimensions matching iOS (aspect ratio 1440:232 per line)
-    val screenWidth = with(density) { configuration.screenWidthDp.dp.toPx() }
-    val lineHeight = screenWidth / 1440f * 232f
 
     CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
         Column(
@@ -86,13 +76,18 @@ fun QuranPageView(
                 juzNumber = juzNumber
             )
 
-            // Lines container. A tap on the reading area that is NOT on a verse (verse
-            // fragments consume their own taps) bubbles up to this Box and fires onPageTap
-            // - the hook a host uses to toggle immersive/full-screen reading, matching iOS.
-            Box(
+            // The 15 lines share the height between the header and the footer, so the whole
+            // page fits one screen with no scrolling - the line is the unit of measure, as
+            // in a printed Mushaf and the iOS viewer. Each line frame is shorter than the
+            // image's natural height; QuranLineImageView crops the top/bottom whitespace to
+            // fit. A tap on the reading area that is NOT on a verse (verse fragments consume
+            // their own taps) bubbles up here and fires onPageTap - the hook a host uses to
+            // toggle immersive/full-screen reading, matching iOS.
+            Column(
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
                     .then(
                         if (onPageTap != null) {
                             Modifier.pointerInput(onPageTap) {
@@ -101,40 +96,31 @@ fun QuranPageView(
                         } else Modifier
                     )
             ) {
-            LazyColumn(
-                state = rememberLazyListState(),
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 16.dp),
-                contentPadding = PaddingValues(vertical = 16.dp)
-            ) {
+                val pageVerses = verses.filter { it.pageNumber == pageNumber }
                 // Render 15 lines (1-15) as images - skip line 0 which is often empty
-                items(15) { index ->
+                repeat(15) { index ->
                     val line = index + 1  // Start from line 1 instead of 0
                     QuranLineImageView(
                         page = pageNumber,
                         line = line,
                         mushafType = mushafType,
-                        verses = verses.filter { it.pageNumber == pageNumber },
+                        verses = pageVerses,
                         selectedVerse = selectedVerse,
                         highlightedVerse = highlightedVerse,
                         pressedVerse = pressedVerse,
                         onVerseClick = onVerseClick,
                         onVerseLongClick = onVerseLongClick,
                         onVersePressChange = { pressedVerse = it },
-                        modifier = Modifier.fillMaxWidth()
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .weight(1f)
                     )
                 }
-
-                // The page-number ornament flows as the last item of the page - it is the
-                // end of the page, not a pinned footer, so it sits right after the final
-                // line (and only comes into view once the reader reaches the bottom),
-                // exactly like the iOS viewer.
-                item {
-                    PageFooter(pageNumber = pageNumber)
-                }
             }
-            } // page-tap Box
+
+            // Page-number ornament, anchored at the bottom of the page. The page fits
+            // without scrolling, so it is always visible, matching the iOS viewer.
+            PageFooter(pageNumber = pageNumber)
         }
     }
 }
@@ -159,7 +145,7 @@ private fun PageHeader(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 20.dp, vertical = 8.dp),
+            .padding(horizontal = 20.dp, vertical = 2.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -200,12 +186,14 @@ private fun PageFooter(pageNumber: Int, modifier: Modifier = Modifier) {
             Image(
                 painter = painterResource(id = R.drawable.pagenumb),
                 contentDescription = null,
-                modifier = Modifier.size(width = 54.dp, height = 36.dp)
+                // iOS PageFooterView frames pagenumb at 42x26 in portrait; match it so the
+                // ornament is not oversized relative to iOS or to the verse-number markers.
+                modifier = Modifier.size(width = 42.dp, height = 26.dp)
             )
             Text(
                 text = convertToArabicNumerals(pageNumber),
                 fontWeight = FontWeight.Bold,
-                fontSize = 14.sp,
+                fontSize = 11.sp,
                 maxLines = 1,
                 color = Color(0xFF2B2B2B),
                 modifier = Modifier.offset(y = (-1).dp)
@@ -214,11 +202,11 @@ private fun PageFooter(pageNumber: Int, modifier: Modifier = Modifier) {
     }
 
     Row(
-        // The reading lines already sit inside the list's 16dp horizontal inset, so a
-        // further 14dp here lands the ornament ~30dp from the screen edge, as on iOS.
+        // ~30dp inset from the screen edge, matching iOS's PageFooterView hPadding.
+        // Minimal vertical padding so the ornament hugs the bottom of the page.
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 14.dp, vertical = 8.dp),
+            .padding(horizontal = 30.dp, vertical = 2.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         if (isRight) {


### PR DESCRIPTION
Closes #94.

Makes a Mushaf page fit the screen with no scrolling (like iOS / a printed Mushaf), right-sizes the page-number ornament, and turns the demo reader into a true full-screen experience that never reflows.

## SDK (mushaf-ui)
- **Fit-to-page, no scroll.** The 15 lines share the height between header and footer (each `weight(1f)`) in a `Column` instead of a scrolling `LazyColumn`. Each line frame is shorter than the image's natural height and the line image **crops** its top/bottom whitespace (`ContentScale.Crop`) rather than scaling — this both fits the page and tightens line spacing, matching iOS's `0.73` crop. Verse-number markers are shifted by the crop offset so they stay on their glyphs.
- **Page-number ornament** anchored at the bottom (always visible) and right-sized to iOS's `42×26` frame (was `54×36`, oversized vs iOS and vs the verse markers). Tighter header/footer padding.

## Demo app (reader UX)
- **Full-screen immersive:** the reader hides the system status/navigation bars for the whole time it is open, so the page uses the entire display and never reflows. Transient-by-swipe lets the user peek the bars; they're restored on leaving the reader.
- **Floating toolbar, no page jump:** the in-app top bar overlays the page (in a `Box`) instead of the Scaffold `topBar` slot. Tapping toggles only this floating bar — the system bars never reappear on tap and the page underneath is **pixel-identical** (verified: lower-page diff = 0).
- Removed a doubled status-bar inset (the parent `QuranApp` Scaffold already insets the screen).

## API
No public API change (`apiCheck` passes without a re-dump).

## Verification
`apiCheck`, `:mushaf-core` + `:mushaf-ui` unit tests, and the v0.1 source-compat fixture all pass; the `source` flavour installs and was checked on device across several pages. Toolbar-toggle no-jump confirmed by a pixel diff of the page region (0.0).

## Screenshots

**Fit-to-page (before scrolls → after fits → iOS):**
![fit](https://github.com/user-attachments/assets/1cf8e9bd-df75-4951-a0fb-7e5c0530b672)

**Page-number ornament right-sized + tighter spacing (page 128):**
![footer](https://github.com/user-attachments/assets/92fddc39-63a2-41fe-873c-5e788637db0b)

**Full-screen reader + floating toolbar (page does not move on tap):**
![fullscreen](https://github.com/user-attachments/assets/5e667872-1eef-4b2f-b8f5-0475c2207872)

## Notes
Part of the iOS-viewer parity work (#89). Remaining viewer gaps tracked in #95 (juz/hizb), #96 (surah-name bar), #97 (fonts), #98 (colours), and small items in #100.
