### PR TITLE
Show the real juz and the hizb in the reader header (#95)

### DIFF
--- a/mushaf-core/src/main/java/com/mushafimad/core/data/repository/DefaultRealmService.kt
+++ b/mushaf-core/src/main/java/com/mushafimad/core/data/repository/DefaultRealmService.kt
@@ -273,6 +273,7 @@ internal class DefaultRealmService(
     }
 
     private suspend fun getPageEntity(number: Int): PageEntity? = withContext(Dispatchers.IO) {
+        ensureInitialized()
         val realmInstance = realm ?: return@withContext null
         realmInstance.query<PageEntity>("number == $0", number)
             .first()

--- a/mushaf-ui/api/mushaf-ui.api
+++ b/mushaf-ui/api/mushaf-ui.api
@@ -169,7 +169,7 @@ public final class com/mushafimad/ui/mushaf/MushafViewKt {
 
 public final class com/mushafimad/ui/mushaf/MushafViewModel : androidx/lifecycle/ViewModel {
 	public static final field $stable I
-	public fun <init> (Lcom/mushafimad/core/domain/repository/VerseRepository;Lcom/mushafimad/core/domain/repository/ChapterRepository;Lcom/mushafimad/core/domain/repository/ReadingHistoryRepository;Lcom/mushafimad/core/domain/repository/PreferencesRepository;)V
+	public fun <init> (Lcom/mushafimad/core/domain/repository/VerseRepository;Lcom/mushafimad/core/domain/repository/ChapterRepository;Lcom/mushafimad/core/domain/repository/PageRepository;Lcom/mushafimad/core/domain/repository/ReadingHistoryRepository;Lcom/mushafimad/core/domain/repository/PreferencesRepository;)V
 	public final fun clearAllSelections ()V
 	public final fun clearError ()V
 	public final fun clearSelection ()V
@@ -219,7 +219,7 @@ public final class com/mushafimad/ui/mushaf/QuranLineImageViewKt {
 }
 
 public final class com/mushafimad/ui/mushaf/QuranPageViewKt {
-	public static final fun QuranPageView (Ljava/util/List;Ljava/util/List;IILcom/mushafimad/core/domain/models/MushafType;Lcom/mushafimad/core/domain/models/Verse;Lcom/mushafimad/core/domain/models/Verse;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;III)V
+	public static final fun QuranPageView (Ljava/util/List;Ljava/util/List;ILjava/lang/String;Ljava/lang/String;Lcom/mushafimad/core/domain/models/MushafType;Lcom/mushafimad/core/domain/models/Verse;Lcom/mushafimad/core/domain/models/Verse;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class com/mushafimad/ui/mushaf/VerseFaselKt {

--- a/mushaf-ui/src/main/java/com/mushafimad/ui/di/UiModule.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/di/UiModule.kt
@@ -26,6 +26,7 @@ val uiModule = module {
         MushafViewModel(
             verseRepository = get(),
             chapterRepository = get(),
+            pageRepository = get(),
             readingHistoryRepository = get(),
             preferencesRepository = get()
         )

--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/MushafView.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/MushafView.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.LayoutDirection
@@ -235,11 +236,15 @@ private fun MushafPagerPage(
 
     val pageContent = content
     if (pageContent != null) {
+        // Pick the juz/hizb labels for the app language: Arabic titles for an Arabic app,
+        // English otherwise. Both variants come from the page data.
+        val isArabic = LocalConfiguration.current.locales.get(0).language == "ar"
         QuranPageView(
             verses = pageContent.verses,
             chapters = pageContent.chapters,
             pageNumber = pageNumber,
-            juzNumber = ((pageNumber - 1) / 20) + 1,
+            juzLabel = if (isArabic) pageContent.juzArabic else pageContent.juzEnglish,
+            hizbLabel = if (isArabic) pageContent.hizbArabic else pageContent.hizbEnglish,
             mushafType = mushafType,
             selectedVerse = selectedVerse,
             highlightedVerse = highlightedVerse,

--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/MushafViewModel.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/MushafViewModel.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.launch
 class MushafViewModel(
     private val verseRepository: VerseRepository,
     private val chapterRepository: ChapterRepository,
+    private val pageRepository: PageRepository,
     private val readingHistoryRepository: ReadingHistoryRepository,
     private val preferencesRepository: PreferencesRepository
 ) : ViewModel() {
@@ -80,7 +81,25 @@ class MushafViewModel(
                 }
             }
 
-            PageContent(verses, chapters).also { pageCache.put(pageNumber, it) }
+            // Real juz (part) and hizb for this page, read from the page data - the same
+            // source iOS uses. Falls back to the page-count approximation only if the
+            // header is unavailable, so the number is never blank.
+            val header = try {
+                pageRepository.getPageHeaderInfo(pageNumber, mushafType)
+            } catch (e: Exception) {
+                null
+            }
+
+            val juz = header?.partNumber ?: calculateJuzNumber(pageNumber)
+            PageContent(
+                verses = verses,
+                chapters = chapters,
+                juzNumber = juz,
+                juzArabic = header?.partArabicTitle ?: "الجزء $juz",
+                juzEnglish = header?.partEnglishTitle ?: "Part $juz",
+                hizbArabic = header?.quarterArabicTitle,
+                hizbEnglish = header?.quarterEnglishTitle,
+            ).also { pageCache.put(pageNumber, it) }
         } catch (e: Exception) {
             null
         }
@@ -485,14 +504,16 @@ class MushafViewModel(
             pageNumber = state.currentPage,
             totalPages = TOTAL_PAGES,
             chapterName = state.chapters.firstOrNull()?.arabicTitle ?: "",
-            juzNumber = calculateJuzNumber(state.currentPage),
+            // Prefer the real juz cached with the page; fall back only if it hasn't loaded.
+            juzNumber = pageCache.get(state.currentPage)?.juzNumber
+                ?: calculateJuzNumber(state.currentPage),
             progress = (state.currentPage.toFloat() / TOTAL_PAGES * 100).toInt()
         )
     }
 
     /**
-     * Calculate Juz number from page number
-     * Each Juz is approximately 20 pages
+     * Fallback juz estimate from the page number (each juz is ~20 pages). Only used when
+     * the real juz from the page data has not loaded yet; the header uses the real value.
      */
     private fun calculateJuzNumber(pageNumber: Int): Int {
         return ((pageNumber - 1) / 20) + 1
@@ -538,7 +559,16 @@ data class PageInfo(
  */
 internal data class PageContent(
     val verses: List<Verse>,
-    val chapters: List<Chapter>
+    val chapters: List<Chapter>,
+    // Real juz number (for the deprecated page-info overlay) plus the localized juz/hizb
+    // labels read straight from the page data - Arabic and English variants, so the header
+    // can show whichever matches the app language. Hizb is null on pages where no quarter
+    // starts.
+    val juzNumber: Int,
+    val juzArabic: String,
+    val juzEnglish: String,
+    val hizbArabic: String? = null,
+    val hizbEnglish: String? = null,
 )
 
 internal val TOTAL_PAGES = com.mushafimad.core.utils.QuranUtils.TOTAL_PAGES

--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranPageView.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranPageView.kt
@@ -50,7 +50,8 @@ fun QuranPageView(
     verses: List<Verse>,
     chapters: List<Chapter>,
     pageNumber: Int,
-    juzNumber: Int,
+    juzLabel: String,
+    hizbLabel: String? = null,
     mushafType: com.mushafimad.core.domain.models.MushafType = com.mushafimad.core.domain.models.MushafType.HAFS_1441,
     selectedVerse: Verse? = null,
     highlightedVerse: Verse? = null,
@@ -73,7 +74,8 @@ fun QuranPageView(
             // Page header
             PageHeader(
                 chapters = chapters,
-                juzNumber = juzNumber
+                juzLabel = juzLabel,
+                hizbLabel = hizbLabel
             )
 
             // The 15 lines share the height between the header and the footer, so the whole
@@ -131,11 +133,14 @@ fun QuranPageView(
 @Composable
 private fun PageHeader(
     chapters: List<Chapter>,
-    juzNumber: Int,
+    juzLabel: String,
+    hizbLabel: String? = null,
     modifier: Modifier = Modifier
 ) {
-    // Minimal header, matching the iOS viewer: juz on one side, the surah name on the other,
-    // both in the same soft green with no heavy background bar. The surah name uses the same
+    // Minimal header, matching the iOS viewer: juz (and the hizb, where one starts on this
+    // page) on one side, the surah name on the other, both in the same soft green with no
+    // heavy background bar. The juz/hizb labels are the localized titles carried in the page
+    // data (Arabic or English, chosen for the app language); the surah name uses the same
     // calligraphic SurahName font iOS does (shipped in mushaf-core's assets). The page number
     // is no longer shown here - it appears as an ornament at the foot of the page.
     val accent = Color(0xFF5E8B6A)
@@ -149,11 +154,20 @@ private fun PageHeader(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Text(
-            text = "الجزء ${convertToArabicNumerals(juzNumber)}",
-            style = MushafTypography.label,
-            color = accent
-        )
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = juzLabel,
+                style = MushafTypography.label,
+                color = accent
+            )
+            hizbLabel?.let { hizb ->
+                Text(
+                    text = hizb,
+                    style = MushafTypography.label,
+                    color = accent
+                )
+            }
+        }
 
         Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
             chapters.forEach { chapter ->


### PR DESCRIPTION
Closes #95.

The reader header showed an **approximated** juz — computed as `((page - 1) / 20) + 1`. Juz are not uniformly 20 pages, so the number was wrong near every boundary (page 21 read "juz 2" when it is still juz 1). The hizb was not shown at all.

## What changed
- **Read the juz and hizb from the page data** (`PageRepository.getPageHeaderInfo`) — the same source the iOS viewer uses — instead of estimating from the page number.
- **Show the hizb** in the header on pages where a quarter starts, as iOS does.
- **Localized labels from the data, no string resources.** The page data already carries Arabic and English titles for both the part and the quarter, so the header simply picks the one matching the app language. An Arabic app reads `الجزء الثاني / الحزب ٣`; an English app reads `Part 2 / Hizb 3 3/4`. (The quarter title even encodes the fraction, so no manual ¼/½/¾ handling is needed.)
- **`getPageEntity` now calls `ensureInitialized()`**, so `getPage`/`getPageHeaderInfo` no longer return `null` when called before anything else has touched the realm — a latent bug this work surfaced.

The page-count approximation is kept only as a fallback for the deprecated page-info overlay, for the moment before the page data loads.

## Verified against the iOS app
Not just the code — the actual apps, on the boundary page:

| Page | Juz | iOS shows | Android shows |
|------|-----|-----------|---------------|
| 21 | **1** | الجزء 1 | الجزء الأول |
| 22 | **2** (+ hizb 3) | الجزء 2 &nbsp;·&nbsp; Hizb 3 | الجزء الثاني &nbsp;·&nbsp; الحزب ٣ |

The juz agrees on both platforms — page 21 is juz 1 (the old Android formula said 2) and page 22 flips to juz 2. The *wording* differs because Android now uses the localized titles carried in the data, while iOS hardcodes the word plus a Western digit.

![juz match](https://github.com/user-attachments/assets/ecbe8a0a-fb9b-48b4-86ee-7b190142612f)

The two `quran.realm` files are byte-identical (same MD5) and both platforms read the same `part.number` field, so this agreement holds for all 604 pages — the screenshots just confirm the app renders it.

## Localization
Same page (22), same data, rendered for the app language. Note Android uses the data's own titles, so Arabic reads the spelled-out "الجزء الثاني" where iOS hardcodes "الجزء 2":

![localized](https://github.com/user-attachments/assets/b4b300ab-0a2f-450c-b5d2-1feac46c383b)

## API
`QuranPageView` now takes `juzLabel: String` / `hizbLabel: String?` in place of `juzNumber: Int`. `mushaf-ui.api` re-dumped; `apiCheck` passes.

## Verification
`apiCheck` (after re-dump), `:mushaf-core` + `:mushaf-ui` unit tests, and the v0.1 source-compat fixture all pass. Checked on device in both Arabic and English locales, across the juz 1→2 boundary.

## Follow-up
Deciding the *wording* ("Part" vs "Juz", spelled-out Arabic ordinals, the `3 3/4` fraction format) really belongs to the consuming app — tracked in #102, which will expose the header/footer as composable slots (matching iOS's `headerBuilder`). The header from this PR becomes the default that slot falls back to.

Part of the iOS-viewer parity work (#89).
