### PR TITLE
Force RTL page turning regardless of host locale (#105)

### DIFF
--- a/mushaf-ui/src/androidTest/java/com/mushafimad/ui/mushaf/PageTurnDirectionTest.kt
+++ b/mushaf-ui/src/androidTest/java/com/mushafimad/ui/mushaf/PageTurnDirectionTest.kt
@@ -1,0 +1,64 @@
+package com.mushafimad.ui.mushaf
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeLeft
+import androidx.compose.ui.test.swipeRight
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * #105: the Mushaf is an Arabic book, so swiping right must always turn to the
+ * next page — even when the host app is LTR. Both tests wrap MushafView in an
+ * explicit LTR layout direction to simulate an English-locale host.
+ */
+@RunWith(AndroidJUnit4::class)
+class PageTurnDirectionTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun swipeRightTurnsToNextPageInLtrHost() {
+        var shown: Int? = null
+        compose.setContent {
+            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                MushafView(initialPage = 50, onPageChanged = { shown = it })
+            }
+        }
+        compose.waitUntil(timeoutMillis = 20_000) { shown == 50 }
+        compose.waitForIdle()
+        Thread.sleep(1500)
+
+        compose.onRoot().performTouchInput { swipeRight() }
+        compose.waitUntil(timeoutMillis = 5_000) { shown != 50 }
+
+        assertThat(shown).isEqualTo(51) // forward through the Mushaf
+    }
+
+    @Test
+    fun swipeLeftTurnsToPreviousPageInLtrHost() {
+        var shown: Int? = null
+        compose.setContent {
+            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                MushafView(initialPage = 50, onPageChanged = { shown = it })
+            }
+        }
+        compose.waitUntil(timeoutMillis = 20_000) { shown == 50 }
+        compose.waitForIdle()
+        Thread.sleep(1500)
+
+        compose.onRoot().performTouchInput { swipeLeft() }
+        compose.waitUntil(timeoutMillis = 5_000) { shown != 50 }
+
+        assertThat(shown).isEqualTo(49) // backward through the Mushaf
+    }
+}

--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/MushafView.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/MushafView.kt
@@ -150,29 +150,33 @@ fun MushafView(
                             .collect { index -> viewModel.onPageSettled(index + 1) }
                     }
 
-                    HorizontalPager(
-                        state = pagerState,
-                        // Pre-compose neighbours so their content is already
-                        // loaded when the swipe starts (issue #70)
-                        beyondViewportPageCount = 1,
-                        // Let a host lock page-turning by swipe (the nav buttons and
-                        // programmatic navigation still work). Default keeps swiping on.
-                        userScrollEnabled = pageSwipeEnabled,
-                        modifier = Modifier.fillMaxSize()
-                    ) { index ->
-                        MushafPagerPage(
-                            pageNumber = index + 1,
-                            mushafType = uiState.mushafType,
-                            selectedVerse = uiState.selectedVerse,
-                            highlightedVerse = highlightedVerse,
-                            onVerseClick = { verse ->
-                                viewModel.selectVerse(verse)
-                                onVerseSelected?.invoke(verse)
-                            },
-                            onVerseLongClick = onVerseLongPress,
-                            onPageTap = onPageTap,
-                            viewModel = viewModel
-                        )
+                    // The Mushaf is an Arabic book: swiping right always turns to the
+                    // next page, whatever the host app's locale (issue #105)
+                    CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+                        HorizontalPager(
+                            state = pagerState,
+                            // Pre-compose neighbours so their content is already
+                            // loaded when the swipe starts (issue #70)
+                            beyondViewportPageCount = 1,
+                            // Let a host lock page-turning by swipe (the nav buttons and
+                            // programmatic navigation still work). Default keeps swiping on.
+                            userScrollEnabled = pageSwipeEnabled,
+                            modifier = Modifier.fillMaxSize()
+                        ) { index ->
+                            MushafPagerPage(
+                                pageNumber = index + 1,
+                                mushafType = uiState.mushafType,
+                                selectedVerse = uiState.selectedVerse,
+                                highlightedVerse = highlightedVerse,
+                                onVerseClick = { verse ->
+                                    viewModel.selectVerse(verse)
+                                    onVerseSelected?.invoke(verse)
+                                },
+                                onVerseLongClick = onVerseLongPress,
+                                onPageTap = onPageTap,
+                                viewModel = viewModel
+                            )
+                        }
                     }
 
                     // Navigation controls overlay


### PR DESCRIPTION
Closes #105. Promoted from the #100 tracker.

The Mushaf is an Arabic book: swiping right must always go forward. The page *content* was already RTL-forced (`QuranPageView`), and so were the nav controls — but the `HorizontalPager` itself was not, so it inherited the host app's layout direction and page-turn direction inverted in any LTR (e.g. English-locale) host.

**Fix:** wrap the pager in `CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl)`. No public API change (`apiCheck` unchanged).

**Test:** new `PageTurnDirectionTest` wraps `MushafView` in an explicitly **LTR** layout direction to simulate an English host, then asserts swipe-right lands on page 51 and swipe-left on page 49 (from 50). Verified the guard can actually fail: with the fix stashed, `swipeRightTurnsToNextPageInLtrHost` fails (lands on 49); with it applied, all 4 direction+swipe-lock tests pass on both local emulators.

Note for reviewers: `PageSwipeLockTest.swipeTurnsPageWhenEnabled` only asserts the page *changed*, not the direction, so it keeps passing across this behaviour change — direction is now pinned by the new test.