### PR TITLE
Match iOS viewer colours: green selection under the ink, themed accent (#98)

### DIFF
--- a/mushaf-ui/api/mushaf-ui.api
+++ b/mushaf-ui/api/mushaf-ui.api
@@ -584,6 +584,7 @@ public final class com/mushafimad/ui/theme/ReadingTheme : java/lang/Enum {
 	public static final field COMFORTABLE Lcom/mushafimad/ui/theme/ReadingTheme;
 	public static final field NIGHT Lcom/mushafimad/ui/theme/ReadingTheme;
 	public static final field WHITE Lcom/mushafimad/ui/theme/ReadingTheme;
+	public final fun getAccentColor-0d7_KjU ()J
 	public final fun getBackgroundColor-0d7_KjU ()J
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getTextColor-0d7_KjU ()J

--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranLineImageView.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranLineImageView.kt
@@ -116,22 +116,11 @@ fun QuranLineImageView(
             }
         }
 
-        // Render line image
-        imageBitmap?.let { bitmap ->
-            Image(
-                bitmap = bitmap,
-                contentDescription = "Quran page $page line $line",
-                // Fill the width and crop the image's top/bottom whitespace: the line frame
-                // is deliberately shorter than the image's natural height so 15 lines fit the
-                // screen, and cropping (not scaling) keeps the glyphs full-size and tightens
-                // line spacing, exactly as the iOS viewer does.
-                contentScale = ContentScale.Crop,
-                colorFilter = ColorFilter.tint(readingTheme.textColor),
-                modifier = Modifier.fillMaxSize()
-            )
-        }
-
-        // Render verse highlights
+        // Render verse highlights. Like the surah bar, these draw BEFORE the line image:
+        // iOS fills the highlight rectangle with SOLID accent900 green underneath the
+        // glyph ink (the line PNG on top is ink-on-transparent), so the text never gets
+        // washed out the way an overlaid translucent tint would. The boxes stay clickable
+        // even under the image - the image has no pointer handlers, so hits pass through.
         verses.forEach { verse ->
             val highlights = when (mushafType) {
                 MushafType.HAFS_1441 -> verse.highlights1441
@@ -181,12 +170,10 @@ fun QuranLineImageView(
                             )
                             .clip(RoundedCornerShape(8.dp))
                             .background(
+                                // One colour for every theme, exactly like iOS's
+                                // universal accent900 asset.
                                 if (shouldHighlight) {
-                                    if (readingTheme.isDark) {
-                                        MushafColors.selectionDark
-                                    } else {
-                                        MushafColors.selectionLight
-                                    }
+                                    MushafColors.selectionLight
                                 } else {
                                     androidx.compose.ui.graphics.Color.Transparent
                                 }
@@ -202,6 +189,22 @@ fun QuranLineImageView(
                     )
                 }
             }
+        }
+
+        // Render line image, ABOVE the surah bar and the highlights (iOS draws its
+        // QuranLineImageView last for the same reason).
+        imageBitmap?.let { bitmap ->
+            Image(
+                bitmap = bitmap,
+                contentDescription = "Quran page $page line $line",
+                // Fill the width and crop the image's top/bottom whitespace: the line frame
+                // is deliberately shorter than the image's natural height so 15 lines fit the
+                // screen, and cropping (not scaling) keeps the glyphs full-size and tightens
+                // line spacing, exactly as the iOS viewer does.
+                contentScale = ContentScale.Crop,
+                colorFilter = ColorFilter.tint(readingTheme.textColor),
+                modifier = Modifier.fillMaxSize()
+            )
         }
 
         // Render verse numbers

--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranPageView.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranPageView.kt
@@ -145,12 +145,13 @@ private fun PageHeader(
     modifier: Modifier = Modifier
 ) {
     // Minimal header, matching the iOS viewer: juz (and the hizb, where one starts on this
-    // page) on one side, the surah name on the other, both in the same soft green with no
-    // heavy background bar. The juz/hizb labels are the localized titles carried in the page
+    // page) on one side, the surah name on the other, both in the reading theme's accent
+    // green (iOS's brand900, which flips to its pale variant on Night) with no heavy
+    // background bar. The juz/hizb labels are the localized titles carried in the page
     // data (Arabic or English, chosen for the app language); the surah name uses the same
     // calligraphic SurahName font iOS does (shipped in mushaf-core's assets). The page number
     // is no longer shown here - it appears as an ornament at the foot of the page.
-    val accent = Color(0xFF5E8B6A)
+    val accent = MaterialTheme.readingTheme.accentColor
     val context = LocalContext.current
     val surahNameFont = remember { FontFamily(Font("SurahName.otf", context.assets)) }
 
@@ -241,7 +242,10 @@ private fun PageFooter(pageNumber: Int, modifier: Modifier = Modifier) {
                 fontSize = fontSize,
                 maxLines = 1,
                 softWrap = false,
-                color = Color(0xFF2B2B2B),
+                // Deliberately NOT theme-derived: the pagenumb ornament's interior is
+                // opaque white in every theme (same SVG on iOS), so black is the only
+                // readable digit colour. iOS's .primary would go white-on-white on Night.
+                color = Color.Black,
                 modifier = Modifier
                     .wrapContentSize(unbounded = true)
                     .offset(y = (-2).dp)

--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/VerseFasel.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/VerseFasel.kt
@@ -69,6 +69,9 @@ fun VerseFasel(
             fontSize = fontSizeSp,
             fontFamily = QuranFonts.UthmanTaha,
             fontWeight = FontWeight.Bold,
+            // Deliberately NOT theme-derived: the fasel ornament's interior is opaque
+            // white in every theme (same SVG on iOS), so black is the only readable
+            // digit colour - see #98.
             color = Color.Black,
             textAlign = TextAlign.Center,
             maxLines = 1,

--- a/mushaf-ui/src/main/java/com/mushafimad/ui/theme/Color.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/theme/Color.kt
@@ -5,14 +5,24 @@ import androidx.compose.ui.graphics.Color
 /**
  * Reading theme colors matching iOS ReadingTheme enum
  * Public API - exposed to library consumers
+ *
+ * accentColor carries iOS's `brand900` (its header/label green): iOS forces the SwiftUI
+ * colorScheme from the reading theme, so brand900 resolves to its light value on the three
+ * light themes and to its dark-appearance value on Night. The two values here are those
+ * two asset variants.
  */
-enum class ReadingTheme(val backgroundColor: Color, val textColor: Color) {
+enum class ReadingTheme(
+    val backgroundColor: Color,
+    val textColor: Color,
+    val accentColor: Color
+) {
     /**
      * Comfortable green theme - default
      */
     COMFORTABLE(
         backgroundColor = Color(0xFFE4EFD9),
-        textColor = Color(0xFF000000)
+        textColor = Color(0xFF000000),
+        accentColor = Color(0xFF015C42)
     ),
 
     /**
@@ -20,7 +30,8 @@ enum class ReadingTheme(val backgroundColor: Color, val textColor: Color) {
      */
     CALM(
         backgroundColor = Color(0xFFE0F1EA),
-        textColor = Color(0xFF000000)
+        textColor = Color(0xFF000000),
+        accentColor = Color(0xFF015C42)
     ),
 
     /**
@@ -28,7 +39,8 @@ enum class ReadingTheme(val backgroundColor: Color, val textColor: Color) {
      */
     NIGHT(
         backgroundColor = Color(0xFF2F352F),
-        textColor = Color(0xFFFFFFFF)
+        textColor = Color(0xFFFFFFFF),
+        accentColor = Color(0xFFE7FBCC)
     ),
 
     /**
@@ -36,7 +48,8 @@ enum class ReadingTheme(val backgroundColor: Color, val textColor: Color) {
      */
     WHITE(
         backgroundColor = Color(0xFFFFFFFF),
-        textColor = Color(0xFF000000)
+        textColor = Color(0xFF000000),
+        accentColor = Color(0xFF015C42)
     );
 
     /**
@@ -195,9 +208,12 @@ object MushafColors {
     val verseHighlightLight = Color(0xFFFFEB3B).copy(alpha = 0.3f)
     val verseHighlightDark = Color(0xFFFDD835).copy(alpha = 0.4f)
 
-    // Selection colors
-    val selectionLight = Color(0xFF2196F3).copy(alpha = 0.2f)
-    val selectionDark = Color(0xFF64B5F6).copy(alpha = 0.3f)
+    // Selection colors - iOS highlights the selected/recited verse with its solid
+    // `accent900` green (#B8F077), drawn BEHIND the glyph ink, and uses the same value
+    // in every reading theme (the asset has no dark variant). Both entries stay for
+    // API compatibility but carry the one iOS value.
+    val selectionLight = Color(0xFFB8F077)
+    val selectionDark = Color(0xFFB8F077)
 
     // Chapter header colors
     val chapterHeaderBackground = Color(0xFFF5F5F5)


### PR DESCRIPTION
Closes #98.

## Verse highlight
iOS fills the selected/recited verse with **solid** `accent900` green (`#B8F077`) drawn **underneath** the glyph ink — its line image renders last in the ZStack. Android painted a translucent blue **over** the ink. Both halves are fixed: the highlight boxes now draw before the line image (like the surah bar already did), and the colour is iOS's universal green in every reading theme (the iOS asset has no dark variant; on Night the white-tinted ink sits on the same green, exactly as iOS renders it). The boxes stay clickable under the image — the image has no pointer handlers, so hits pass through.

`MushafColors.selectionLight/Dark` are kept for API compatibility but both now carry the one iOS value.

## Header accent
The juz/hizb/surah-name labels were hardcoded `#5E8B6A` — which matches nothing on iOS. iOS uses `brand900` and forces the SwiftUI `colorScheme` from the reading theme, so it resolves to **`#015C42`** on the three light themes and **`#E7FBCC`** on Night. Ported as `ReadingTheme.accentColor` (new public property, apiDump +1) with those exact asset values; verified on-device that the Night header renders `#E7FBCC` to the pixel.

## Digit colours — deliberate non-change
The fasel and page-number digits stay black in every theme, now documented in-code: both ornaments' interiors are **opaque white** (same SVG on both platforms), so black is the only readable digit colour. iOS's `.primary` digits would go white-on-white on Night — a bug we chose not to port.

## Verified
Unit tests, `apiCheck` (one intentional addition), `:app:assembleSourceDebug`, and on-device screenshots below (before from a detached `release/0.3.0` checkout, after in White and Night).

![selection-evidence.png](https://github.com/user-attachments/assets/61797bc5-c661-470f-b614-059c72a7ddb9)