### PR TITLE
Run the 15 lines at full page width like iOS (#100)

### DIFF
--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranPageView.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranPageView.kt
@@ -88,14 +88,15 @@ fun QuranPageView(
             // page fits one screen with no scrolling - the line is the unit of measure, as
             // in a printed Mushaf and the iOS viewer. Each line frame is shorter than the
             // image's natural height; QuranLineImageView crops the top/bottom whitespace to
-            // fit. A tap on the reading area that is NOT on a verse (verse fragments consume
-            // their own taps) bubbles up here and fires onPageTap - the hook a host uses to
-            // toggle immersive/full-screen reading, matching iOS.
+            // fit. Lines run the FULL page width - iOS pads only the header row, not the
+            // line stack, and everything on the line (text scale, surah-name bar) derives
+            // from this width. A tap on the reading area that is NOT on a verse (verse
+            // fragments consume their own taps) bubbles up here and fires onPageTap - the
+            // hook a host uses to toggle immersive/full-screen reading, matching iOS.
             Column(
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
                     .then(
                         if (onPageTap != null) {
                             Modifier.pointerInput(onPageTap) {


### PR DESCRIPTION
Closes two #100 tracker items at their shared root cause: **line horizontal inset vs iOS** and **"surah name looks small"** (the in-page ornament bar).

## The one-line change
iOS pads only the header row; its line VStack runs the full page width, and everything on a line — the crop-scaled text and the surah-name bar (`containerWidth * 0.9`) — derives from that width. Android additionally inset the line column by 16dp per side, so text and bar were uniformly ~8% narrower than iOS on a 411dp phone. The padding is removed; the formulas need no change.

## Verified
- Measured ink width on the same page-2 line: before/after ratio is **1.084 = 1080/996 px exactly** — the inset, nothing else.
- The residual margin inside a line is the PNG's own content (same assets on iOS), so line width is now identical to iOS by construction; cross-checked against an iPhone 17 Pro simulator page whose text ink spans 93% of the screen the way Android's now does.
- Highlight tap-targets and the fasel/bar positions all derive from the same `containerWidth`, so they scale with it automatically — the full `mushaf-ui` instrumented suite (swipe lock, page-turn direction) passes on both local emulators; unit tests + `apiCheck` green (no API change).

![inset-evidence.png](https://github.com/user-attachments/assets/b83acdfe-1808-4098-b179-cd51367a167a)