### PR TITLE
Pin lines to iOS's width-derived height so sparse pages stay compact (#100)

### DIFF
--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranPageView.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranPageView.kt
@@ -84,16 +84,16 @@ fun QuranPageView(
                 hizbLabel = hizbLabel
             )
 
-            // The 15 lines share the height between the header and the footer, so the whole
-            // page fits one screen with no scrolling - the line is the unit of measure, as
-            // in a printed Mushaf and the iOS viewer. Each line frame is shorter than the
-            // image's natural height; QuranLineImageView crops the top/bottom whitespace to
-            // fit. Lines run the FULL page width - iOS pads only the header row, not the
-            // line stack, and everything on the line (text scale, surah-name bar) derives
-            // from this width. A tap on the reading area that is NOT on a verse (verse
-            // fragments consume their own taps) bubbles up here and fires onPageTap - the
-            // hook a host uses to toggle immersive/full-screen reading, matching iOS.
-            Column(
+            // The 15 lines between the header and the footer - the line is the unit of
+            // measure, as in a printed Mushaf and the iOS viewer. Each line frame is
+            // shorter than the image's natural height; QuranLineImageView crops the
+            // top/bottom whitespace to fit. Lines run the FULL page width - iOS pads only
+            // the header row, not the line stack, and everything on the line (text scale,
+            // surah-name bar) derives from this width. A tap on the reading area that is
+            // NOT on a verse (verse fragments consume their own taps) bubbles up here and
+            // fires onPageTap - the hook a host uses to toggle immersive/full-screen
+            // reading, matching iOS.
+            BoxWithConstraints(
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth()
@@ -105,26 +105,38 @@ fun QuranPageView(
                         } else Modifier
                     )
             ) {
-                val pageVerses = verses.filter { it.pageNumber == pageNumber }
-                // Render 15 lines (1-15) as images - skip line 0 which is often empty
-                repeat(15) { index ->
-                    val line = index + 1  // Start from line 1 instead of 0
-                    QuranLineImageView(
-                        page = pageNumber,
-                        line = line,
-                        mushafType = mushafType,
-                        verses = pageVerses,
-                        chapterHeaders = chapterHeaders,
-                        selectedVerse = selectedVerse,
-                        highlightedVerse = highlightedVerse,
-                        pressedVerse = pressedVerse,
-                        onVerseClick = onVerseClick,
-                        onVerseLongClick = onVerseLongClick,
-                        onVersePressChange = { pressedVerse = it },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .weight(1f)
-                    )
+                // Every line - blank or not - is pinned to the height iOS uses: derived
+                // from the page WIDTH alone (the 1440x232 image aspect x a 0.73 crop
+                // factor, QuranPageView.swift:68,118), with the leftover height sitting
+                // BELOW the last line, before the footer. Dividing the height equally
+                // instead (the old model) made every blank slot on a sparse page claim a
+                // full uncapped 1/15 share, stretching pages 1-2's few real lines apart,
+                // and loosened line spacing on tall screens. The equal share remains only
+                // as a CAP so short/wide screens still fit all 15 lines with no scrolling
+                // (fit-to-page, #94).
+                val lineHeight = minOf(maxWidth / (1440f / 232f) * 0.73f, maxHeight / 15)
+                Column(modifier = Modifier.fillMaxSize()) {
+                    val pageVerses = verses.filter { it.pageNumber == pageNumber }
+                    // Render 15 lines (1-15) as images - skip line 0 which is often empty
+                    repeat(15) { index ->
+                        val line = index + 1  // Start from line 1 instead of 0
+                        QuranLineImageView(
+                            page = pageNumber,
+                            line = line,
+                            mushafType = mushafType,
+                            verses = pageVerses,
+                            chapterHeaders = chapterHeaders,
+                            selectedVerse = selectedVerse,
+                            highlightedVerse = highlightedVerse,
+                            pressedVerse = pressedVerse,
+                            onVerseClick = onVerseClick,
+                            onVerseLongClick = onVerseLongClick,
+                            onVersePressChange = { pressedVerse = it },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(lineHeight)
+                        )
+                    }
                 }
             }
 


### PR DESCRIPTION
Closes two #100 tracker items with one mechanism: **sparse pages (1-2) rendering small in a mostly-empty page**, and **line spacing looser than iOS on tall screens**.

## What was wrong
Android divided the between-header-and-footer height equally across all 15 line slots (`weight(1f)` each). Pages 1-2 ship 7 of their 15 line PNGs as transparent placeholders, and each blank slot still claimed a full uncapped 1/15 share — stretching the few real lines apart. The same mechanism made *every* page's line spacing looser than iOS on tall screens.

## The iOS model, ported
iOS pins every line - blank or not - to a height derived from the page **width** alone (`width/1440*232 × 0.73`, `QuranPageView.swift:68,118`) and lets one trailing `Spacer()` absorb whatever is left before the footer. Now Android does the same: `BoxWithConstraints` computes that height, every line gets it, and the leftover collects below the last line. The old equal share survives only as a **cap** (`min` with `maxHeight/15`) so short/wide screens still fit all 15 lines with no scrolling - fit-to-page (#94) can't regress into overflow.

## Verified
- On-device before/after for pages 1, 2 (sparse) and 3 (full): sparse pages tighten to iOS's rhythm with the blank band consolidated at the bottom; the full page keeps all 15 lines with the same fixed spacing (screenshots below, baselines from a detached `release/0.3.0` checkout).
- Unit tests, `apiCheck` (no API change), `:app:assembleSourceDebug` green.

![sparse-evidence.png](https://github.com/user-attachments/assets/bac080e2-5d04-45cf-a0a2-ea541881e583)