### PR TITLE
Clip only the line image, not the whole line box (#112)

### DIFF
--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranLineImageView.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranLineImageView.kt
@@ -75,9 +75,13 @@ fun QuranLineImageView(
         imageBitmap = loadLineImage(context, page, line)
     }
 
+    // NOT clipped as a whole: the surah-name bar (and, at the margins, the fasel
+    // markers) are deliberately taller than the line frame and must overflow it,
+    // exactly as iOS's unclipped line ZStack allows. Clipping here (as fit-to-page
+    // #94 once did) cuts the bar's top/bottom rules wherever the frame is short -
+    // e.g. tablet portrait (#112). Only the line IMAGE is clipped, below.
     Box(
         modifier = modifier
-            .clipToBounds()
             .onGloballyPositioned { coordinates ->
                 with(density) {
                     containerWidth = coordinates.size.width.toFloat()
@@ -203,7 +207,12 @@ fun QuranLineImageView(
                 // line spacing, exactly as the iOS viewer does.
                 contentScale = ContentScale.Crop,
                 colorFilter = ColorFilter.tint(readingTheme.textColor),
-                modifier = Modifier.fillMaxSize()
+                // Clip the IMAGE only (iOS `.clipped()` on its Image likewise): Crop
+                // scales the bitmap past the frame and without this it would bleed
+                // into the neighbouring lines.
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clipToBounds()
             )
         }
 

--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranLineImageView.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranLineImageView.kt
@@ -101,7 +101,14 @@ fun QuranLineImageView(
                 val barWidth = containerWidth * 0.9f
                 val barHeight = scaledImageHeight * 0.8f
                 val centerX = containerWidth * (1.0f - header.centerX)
-                val centerY = scaledImageHeight * header.centerY - cropOffset
+                // The header's data point sits above the visual centre of the name text
+                // baked into the PNG, so iOS nudges the frame down 8pt when placing it
+                // (QuranPageView.swift `.position(y: chapterY + 8)`). 8pt is ~1/8 of the
+                // scaled image height on the iPhone widths that constant was tuned for;
+                // ported proportionally so the text stays centred at any page width.
+                // The old whole-box clipping hid this offset by cropping the frame (#112).
+                val centerY =
+                    scaledImageHeight * header.centerY - cropOffset + scaledImageHeight * 0.125f
 
                 Image(
                     painter = painterResource(id = R.drawable.suranamebar),


### PR DESCRIPTION
Closes #112 (spotted by the user in #111's tablet screenshot: the surah-name bar had lost its top/bottom ornamental rules).

## Cause
Fit-to-page (#94) put `clipToBounds()` on the whole line Box to stop the crop-scaled line **image** bleeding into neighbouring lines — but that also clips the surah-name bar, which is deliberately taller than the line frame (0.8x scaled image height). On phones only ~5% is shaved and the rules survive; in the tablet's cap mode (~0.58x frame) ~13% goes from each side and the rules vanish.

## Fix (iOS parity)
iOS clips only its line Image (`.clipped()`, `QuranLineImageView.swift:53`) and lets the bar and fasel markers overflow their slot in the unclipped line ZStack. Android now does the same: the clip moved from the line Box onto the line Image alone.

## Verified
- Tablet portrait: full frame restored (below).
- Phone: pixel-diff against the pre-change render of the same page is a **623x4px strip at the bar's top rule** — the restored pixels — and nothing else; no image bleed anywhere.
- Full `mushaf-ui` instrumented suite on both phone emulators, unit tests, `apiCheck` all green.

![bar-evidence.png](https://github.com/user-attachments/assets/95b534d4-0098-4cf5-989e-3fd27af67628)