### PR TITLE
Fill full pages to the footer and fix the surah-bar height clamp (#114)

### DIFF
--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranLineImageView.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranLineImageView.kt
@@ -13,12 +13,15 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
+import kotlin.math.roundToInt
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
@@ -101,24 +104,30 @@ fun QuranLineImageView(
                 val barWidth = containerWidth * 0.9f
                 val barHeight = scaledImageHeight * 0.8f
                 val centerX = containerWidth * (1.0f - header.centerX)
-                // The header's data point sits above the visual centre of the name text
-                // baked into the PNG, so iOS nudges the frame down 8pt when placing it
-                // (QuranPageView.swift `.position(y: chapterY + 8)`). 8pt is ~1/8 of the
-                // scaled image height on the iPhone widths that constant was tuned for;
-                // ported proportionally so the text stays centred at any page width.
-                // The old whole-box clipping hid this offset by cropping the frame (#112).
-                val centerY =
-                    scaledImageHeight * header.centerY - cropOffset + scaledImageHeight * 0.125f
+                val centerY = scaledImageHeight * header.centerY - cropOffset
 
                 Image(
                     painter = painterResource(id = R.drawable.suranamebar),
                     contentDescription = null,
                     contentScale = ContentScale.FillBounds,
+                    // Measured OUTSIDE the parent's constraints: the bar is deliberately
+                    // taller than the line frame, and a plain size() request gets CLAMPED
+                    // to the line height - which squashed the frame and, because the
+                    // offset still assumed the full height, shifted it up by half the
+                    // overflow. That clamp was the real source of every "surah name not
+                    // centred in its bar" report (#112, #114 review); iOS never hits it
+                    // because SwiftUI frames don't constrain children. wrapContentSize
+                    // with unbounded=true measures the child free of the parent's max
+                    // constraints; TopStart alignment keeps the true box anchored to the
+                    // offset, so the centre math holds at any line pitch.
                     modifier = Modifier
-                        .offset(
-                            x = with(density) { (centerX - barWidth / 2f).toDp() },
-                            y = with(density) { (centerY - barHeight / 2f).toDp() }
-                        )
+                        .offset {
+                            IntOffset(
+                                (centerX - barWidth / 2f).roundToInt(),
+                                (centerY - barHeight / 2f).roundToInt()
+                            )
+                        }
+                        .wrapContentSize(align = Alignment.TopStart, unbounded = true)
                         .size(
                             width = with(density) { barWidth.toDp() },
                             height = with(density) { barHeight.toDp() }

--- a/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranPageView.kt
+++ b/mushaf-ui/src/main/java/com/mushafimad/ui/mushaf/QuranPageView.kt
@@ -105,18 +105,33 @@ fun QuranPageView(
                         } else Modifier
                     )
             ) {
-                // Every line - blank or not - is pinned to the height iOS uses: derived
-                // from the page WIDTH alone (the 1440x232 image aspect x a 0.73 crop
-                // factor, QuranPageView.swift:68,118), with the leftover height sitting
-                // BELOW the last line, before the footer. Dividing the height equally
-                // instead (the old model) made every blank slot on a sparse page claim a
-                // full uncapped 1/15 share, stretching pages 1-2's few real lines apart,
-                // and loosened line spacing on tall screens. The equal share remains only
-                // as a CAP so short/wide screens still fit all 15 lines with no scrolling
-                // (fit-to-page, #94).
-                val lineHeight = minOf(maxWidth / (1440f / 232f) * 0.73f, maxHeight / 15)
+                // Line pitch. iOS pins every line to a width-derived height (the 1440x232
+                // image aspect x a 0.73 crop factor, QuranPageView.swift:68,118) and lets
+                // one trailing spacer take the leftover - which on iPhone aspect ratios is
+                // ~ZERO, so iOS pages visually FILL the space down to the footer. Android
+                // phones are taller: the same pinned pitch left ~12% of the content area
+                // as a blank band at the bottom (#114). So:
+                //  - FULL pages (content on all 15 lines - every page but 1 and 2) take
+                //    the equal share of the available height, filling to the footer the
+                //    way iOS looks on its own hardware; capped at the image's natural
+                //    height so an extreme aspect can never letterbox a line.
+                //  - SPARSE pages (any line with neither a verse fragment nor a chapter
+                //    header on it) keep the iOS pinned pitch, so their blank slots stay
+                //    small instead of stretching the few real lines apart (#110).
+                val pageVerses = verses.filter { it.pageNumber == pageNumber }
+                // Pages 1 and 2 are this mushaf's only sparse pages: they ship 7 of their
+                // 15 line PNGs as blank placeholders. Every other page's 15 lines all
+                // carry real ink (verses, surah bars, or bismillahs - note bismillah
+                // lines have no verse/header DATA, so this cannot be derived from the
+                // page's verse fragments; it is a fixed property of the shipped assets).
+                val isSparse = pageNumber <= 2
+                val scaledImageHeight = maxWidth / (1440f / 232f)
+                val lineHeight = if (isSparse) {
+                    minOf(scaledImageHeight * 0.73f, maxHeight / 15)
+                } else {
+                    minOf(scaledImageHeight, maxHeight / 15)
+                }
                 Column(modifier = Modifier.fillMaxSize()) {
-                    val pageVerses = verses.filter { it.pageNumber == pageNumber }
                     // Render 15 lines (1-15) as images - skip line 0 which is often empty
                     repeat(15) { index ->
                         val line = index + 1  // Start from line 1 instead of 0


### PR DESCRIPTION
Closes #114. Two commits, two fixes that surfaced together.

## 1. Vertical distribution (the #114 report)
#110 pinned every line to iOS's width-derived pitch. On iPhone aspect ratios that formula *exactly fills* the header-to-footer space (measured: iOS content ink runs to ~94% of the content area) — but Android phones are taller, so ~12% of the content area pooled at the bottom and the top read as cramped. Now **full pages take the equal share of the available height** (capped at the image's natural height so no aspect can letterbox a line), reproducing what iOS actually looks like on its own hardware; **sparse pages 1–2 keep the pinned pitch** so their blank placeholder slots stay small (the #110 fix is preserved — note sparseness cannot be derived from verse data because bismillah lines carry none; it is a fixed property of the shipped assets, so pages 1–2 are named explicitly).

Measured on the same emulator/pages as the attribution in #114: content ink now ends at **93.7% with ~0% bottom band** (was 81.5%/12%); pages 1–2 byte-identical in distribution to the previous build.

## 2. The surah-bar height clamp (found while validating, root cause of every centring report)
The bar Image requested `0.8 x scaled-image-height` via `size()` — but a size request is clamped by the parent line-box's constraints. Whenever the bar was taller than the line (tablet cap mode, phones at pinned pitch), it was **squashed to line height and, because the offset assumed full height, shifted up by half the overflow**. That single mechanism explains, to the pixel, every symptom we chased: the tablet's "name low" (+14.7% = 22px = overflow/2), the phone's "name high" after the #113 nudge, and the squashed 125px frames in earlier captures. Fixed with `wrapContentSize(unbounded = true)` so the bar measures free of the parent's constraints; **the #113 nudge is removed** — it was compensating this clamp, not a data offset, and iOS's own `+8pt` fudge is unnecessary here once the geometry is honest.

Name-in-frame offsets after the fix, measured against the frame rules: **phone +0.4/+1.1/+0.4%, tablet +1.2%** — iOS itself measures +1.1/+3.8/+2.2% on the user's simulator screenshots.

## Verified
Full `mushaf-ui` instrumented suite on both phone emulators; unit tests; `apiCheck` (no API change); deterministic before/after captures on phone (pages 1, 2, 601, 604) and tablet (page 1).

![barsCol.png](https://github.com/user-attachments/assets/8d0dd5d7-383c-4ce1-9a51-b8d24dc5bfc9)

![pagesRow.png](https://github.com/user-attachments/assets/52e87c1a-65a0-44c3-a4fe-81abfd2e65b7)