### PR TITLE
Add a script to report JitPack download counts per version (#119)

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,37 @@ in two product flavours against two different spellings of the same library:
 
 ---
 
+## Release Tooling
+
+`scripts/jitpack-stats.sh` reports how often the published library is actually being
+resolved, one row per version, plus the APK download counts from the GitHub releases:
+
+```bash
+./scripts/jitpack-stats.sh              # this library
+./scripts/jitpack-stats.sh owner/repo   # any other JitPack library
+```
+
+```
+  VERSION      BUILD        WEEK    MONTH
+  0.3.0        ok             15       15
+  0.2.3        ok              7        7
+  ...
+  ALL                         15       56
+```
+
+It reads JitPack's undocumented stats endpoint — the one the "Stats" tab on jitpack.io
+uses — and takes the version list from the builds API, so a tag that JitPack never built
+successfully (and therefore nobody can consume) is correctly left out.
+
+Read the numbers as a floor rather than an install count: only **week** and **month**
+windows exist, there is no per-module breakdown, and anything resolved from a cache or a
+mirror never reaches JitPack to be counted.
+
+`scripts/verify-aar.sh` checks a published artifact from a consumer's point of view; see
+**App** above for the `published` flavour that builds against it.
+
+---
+
 ## Project Status
 
 **Version:** 0.3.0

--- a/scripts/jitpack-stats.sh
+++ b/scripts/jitpack-stats.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Show JitPack download counts per published version, plus GitHub APK downloads.
+#
+#   scripts/jitpack-stats.sh                       # this library
+#   scripts/jitpack-stats.sh other-owner/other-repo
+#
+# JitPack's stats endpoint is undocumented (it is what the "Stats" tab on
+# jitpack.io uses). Only week and month windows exist - there is no all-time
+# total, and no per-module breakdown (module paths always answer 0).
+# It counts what resolves through JitPack, so cached or mirrored consumers are
+# invisible: read these as a floor, not a true install count.
+set -euo pipefail
+
+SLUG="${1:-YahiaRagae/mushaf-imad-android}"
+OWNER="${SLUG%%/*}"
+REPO="${SLUG##*/}"
+GROUP="com.github.${OWNER}"
+API="https://jitpack.io/api"
+
+command -v jq >/dev/null || { echo "needs jq: brew install jq" >&2; exit 1; }
+
+get() { curl -sS --max-time 30 "$1"; }
+
+# The versions come from the builds API - the same endpoint that reports whether
+# each version built. That is the answer to "how do I list versions": there is no
+# separate versions API, and this one is better than git tags because a tag that
+# JitPack never built successfully is not actually consumable.
+builds_json="$(get "${API}/builds/${GROUP}/${REPO}")"
+versions="$(jq -r --arg g "$GROUP" --arg r "$REPO" '.[$g][$r] // {} | keys[]' <<<"$builds_json" 2>/dev/null || true)"
+
+if [ -z "$versions" ]; then
+  echo "No published versions found for ${GROUP}:${REPO}" >&2
+  exit 1
+fi
+
+total="$(get "${API}/stats/${GROUP}/${REPO}")"
+echo "JitPack downloads - ${GROUP}:${REPO}"
+echo
+printf '  %-12s %-8s %8s %8s\n' VERSION BUILD WEEK MONTH
+printf '  %-12s %-8s %8s %8s\n' ------------ -------- -------- --------
+
+# Newest first: sort by version segments numerically.
+while read -r v; do
+  [ -n "$v" ] || continue
+  build="$(jq -r --arg g "$GROUP" --arg r "$REPO" --arg v "$v" '.[$g][$r][$v]' <<<"$builds_json")"
+  s="$(get "${API}/stats/${GROUP}/${REPO}/${v}")"
+  printf '  %-12s %-8s %8s %8s\n' \
+    "$v" "$build" \
+    "$(jq -r '.week  // 0' <<<"$s")" \
+    "$(jq -r '.month // 0' <<<"$s")"
+done < <(sort -t. -k1,1nr -k2,2nr -k3,3nr <<<"$versions")
+
+printf '  %-12s %-8s %8s %8s\n' ------------ -------- -------- --------
+printf '  %-12s %-8s %8s %8s\n' 'ALL' '' \
+  "$(jq -r '.week  // 0' <<<"$total")" \
+  "$(jq -r '.month // 0' <<<"$total")"
+echo
+echo "  Note: per-version figures do not sum to ALL - JitPack counts them"
+echo "  differently. Treat the breakdown as indicative."
+
+# APK downloads are a separate metric: GitHub only counts release ASSETS.
+if command -v gh >/dev/null; then
+  apk="$(gh api "repos/${SLUG}/releases" \
+        --jq '[.[] | select(.assets | length > 0)
+               | "  \(.tag_name): " + ([.assets[] | "\(.name) = \(.download_count)"] | join(", "))] | join("\n")' \
+        2>/dev/null || true)"
+  if [ -n "$apk" ]; then
+    echo
+    echo "GitHub release assets (APK downloads)"
+    echo
+    echo "$apk"
+  fi
+fi


### PR DESCRIPTION
Closes #119.

## What it adds
`scripts/jitpack-stats.sh` — one row per published version, plus the repo total and the APK download counts from the GitHub releases:

```
  VERSION      BUILD        WEEK    MONTH
  0.3.0        ok             15       15
  0.2.3        ok              7        7
  0.2.2        ok              3        3
  0.2.1        ok             17       17
  0.1          ok              1        7
  ALL                         15       56
```

Takes an optional `owner/repo`, so it works against any JitPack library, not just this one.

## Two decisions worth flagging
**Versions come from the builds API, not git tags.** `/api/builds/{group}/{repo}` also reports whether each version built, and a tag JitPack never built successfully is not actually consumable — 0.2.0 is exactly that case, and it is correctly absent from the output.

**The caveats are written into the script and the README, not left implicit**, because the endpoint is undocumented and the numbers are easy to over-read:
- only week and month windows exist (no all-time; `?period=year` is ignored)
- no per-module breakdown — module paths always answer `0`, which is the path form not being tracked rather than a real zero
- per-version figures do not sum to the repo total, so they are indicative
- it counts only what resolves *through* JitPack, so cached or mirrored consumers are invisible — a floor, not an install count

I verified the per-version path is genuinely version-aware rather than echoing a default: nonexistent versions (`99.99.99`, `banana`) return zeros while real ones return distinct values.

## README
New **Release Tooling** section documenting the script, with a cross-reference to the existing `scripts/verify-aar.sh` and the `published` flavour.

## Verified
`shellcheck` clean, `bash -n` clean, and the script runs green against the live API (output above is its real output). No library code touched, so the release path filter will skip this — merging it will not cut a version.