### PR TITLE
Add MIT license and ITQAN Community acknowledgment

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Itqan Community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -612,6 +612,14 @@ Developed with care for the Muslim community.
 - Audio recitations from various reciters
 - Open source libraries: Jetpack Compose, Realm, ExoPlayer, Koin
 
+Special thanks to the [ITQAN Community](https://community.itqan.dev) for their support and contribution to the Quran technology ecosystem.
+
+<p align="center">
+  <a href="https://itqan.dev">
+    <img src="https://itqan.dev/logo.svg" alt="ITQAN Community Logo" width="150" />
+  </a>
+</p>
+
 ---
 
 **Last Updated:** July 2026

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Quran reader library for Android providing high-quality Mushaf page display wi
 [![Version](https://img.shields.io/badge/Version-0.3.0-blue.svg)](https://github.com/YahiaRagae/mushaf-imad-android/releases/tag/0.3.0)
 [![JitPack](https://jitpack.io/v/YahiaRagae/mushaf-imad-android.svg)](https://jitpack.io/#YahiaRagae/mushaf-imad-android)
 [![Status](https://img.shields.io/badge/Status-Stable-green.svg)](https://github.com/YahiaRagae/mushaf-imad-android)
+[![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 > ✅ **Version 0.3.0:** The reader now renders the Mushaf the way the iOS viewer does — the page fits the screen with no scrolling, surah-name and page-number ornaments are drawn in place, the real KFGQPC digit font ships with the library, and page turning is always right-to-left whatever your app's locale. Landscape switches to a vertical scroll. The public API gains only `ReadingTheme.accentColor`, so 0.2.x code compiles as-is.
 
@@ -589,6 +590,12 @@ The library is currently undergoing QA validation. Test cases are tracked as [Gi
 ## Repository
 
 **GitHub:** [https://github.com/YahiaRagae/mushaf-imad-android](https://github.com/YahiaRagae/mushaf-imad-android)
+
+---
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).
 
 ---
 


### PR DESCRIPTION
Closes #122

## What

- Adds a `LICENSE` file (MIT, **Copyright (c) 2026 Itqan Community**) — the repo had none, so GitHub showed no license and consumers had no usage terms.
- Adds a **License** section + MIT badge to the README (the Flutter repo has the same section; ours links the file directly).
- Adds the ITQAN Community acknowledgment and logo to the README footer, matching the React Native repo (`adelpro/mushaf-imad-expo`).

## Why MIT / Itqan Community

Every licensed repo in the Mushaf Imad family is MIT:

| Repo | License | Copyright |
|---|---|---|
| iOS (`ibo2001/MushafImad`) | MIT | Ibrahim Qraiqe |
| Flutter (`Itqan-community/mushaf-imad-flutter`) | MIT | Itqan Community |
| Android (this PR) | MIT | Itqan Community |

The copyright line follows the Flutter repo's convention of attributing to the community.

Docs-only change: CI's release job will correctly skip.

Supersedes #121 (closed to follow the issue-first workflow).

https://claude.ai/code/session_01NRzdcQ1giwWqDGnBFEiLtK